### PR TITLE
Update to sysml-v2-parser 0.51.1, fix connection-end reference handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2157,9 +2157,9 @@ dependencies = [
 
 [[package]]
 name = "sysml-v2-parser"
-version = "0.51.0"
+version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8d6cbe9dbfe1e0c0e03bd29974c05b4cac9fbaa296b98fec6c4ea9a6480cbd"
+checksum = "dd95a80d6ce4e56ff35a82ccab7fa9d7db51e4cd26a01a25571333f417dc76f5"
 dependencies = [
  "log",
  "nom",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,9 +84,18 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
+
+[[package]]
+name = "ar_archive_writer"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73cd58deff2140a0a8eae87e417bd01db68a33e148aa93d1e8cd837e55e312b6"
+dependencies = [
+ "object",
+]
 
 [[package]]
 name = "arbitrary"
@@ -99,13 +108,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -122,7 +131,7 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -217,9 +226,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
@@ -254,15 +263,15 @@ checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -276,9 +285,20 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core",
+]
 
 [[package]]
 name = "chrono"
@@ -296,9 +316,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -306,9 +326,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -318,14 +338,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -356,6 +376,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,9 +395,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -376,18 +405,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crypto-common"
@@ -420,7 +449,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -431,7 +460,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -455,7 +484,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -507,13 +536,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -524,9 +553,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "equivalent"
@@ -546,9 +575,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
@@ -601,9 +630,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -616,9 +645,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -626,15 +655,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -643,38 +672,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -712,36 +741,23 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi 5.3.0",
- "wasip2",
+ "r-efi",
+ "rand_core",
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 6.0.0",
- "wasip2",
- "wasip3",
-]
-
-[[package]]
 name = "glob"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "globset"
@@ -796,9 +812,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -806,9 +822,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -816,9 +832,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -841,9 +857,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1006,12 +1022,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1062,8 +1072,6 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -1086,9 +1094,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.100"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1105,7 +1113,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "walkdir",
  "zip",
 ]
@@ -1129,22 +1137,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libredox"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
  "libc",
 ]
@@ -1172,9 +1174,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru-slab"
@@ -1213,7 +1215,7 @@ dependencies = [
  "sysml_model",
  "sysml_tokens",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "toml",
  "tower-lsp",
@@ -1242,9 +1244,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "mime"
@@ -1264,9 +1266,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
@@ -1279,7 +1281,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -1321,6 +1323,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "object"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1406,7 +1417,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1425,29 +1436,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -1467,10 +1459,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "quinn"
-version = "0.11.9"
+name = "psm"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -1480,7 +1482,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "web-time",
@@ -1488,20 +1490,21 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
  "rand",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1509,32 +1512,26 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-efi"
@@ -1544,31 +1541,28 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
+ "chacha20",
+ "getrandom 0.4.3",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.5"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
- "getrandom 0.3.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -1597,7 +1591,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -1613,29 +1607,29 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1726,7 +1720,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -1743,7 +1737,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1777,9 +1771,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustix"
@@ -1787,7 +1781,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1796,9 +1790,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "once_cell",
  "ring",
@@ -1810,9 +1804,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -1831,9 +1825,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu"
@@ -1852,9 +1846,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
 dependencies = [
  "chrono",
  "dyn-clone",
@@ -1866,14 +1860,14 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+checksum = "d98c67716b46af2f0b8cf752abc930f6f9aecfbf671ecfb531db8a31dbe4e2ba"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1883,16 +1877,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "semver"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-
-[[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -1900,40 +1888,40 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_derive_internals"
-version = "0.29.1"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -1955,13 +1943,13 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2037,7 +2025,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2068,9 +2056,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "slab"
@@ -2080,15 +2068,15 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -2099,6 +2087,19 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stacker"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "640c8cdd92b6b12f5bcb1803ca3bbf5ab96e5e6b6b96b9ab77dabe9e880b3190"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "strsim"
@@ -2114,9 +2115,20 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2140,19 +2152,20 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "sysml-v2-parser"
-version = "0.50.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1602448e863aa908a2270ec7a8d57983e4aa67283c3932eefff08c9f0b1751f"
+checksum = "db8d6cbe9dbfe1e0c0e03bd29974c05b4cac9fbaa296b98fec6c4ea9a6480cbd"
 dependencies = [
  "log",
  "nom",
  "nom_locate",
  "serde",
+ "stacker",
 ]
 
 [[package]]
@@ -2197,7 +2210,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2223,11 +2236,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.19",
 ]
 
 [[package]]
@@ -2238,25 +2251,25 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
@@ -2273,9 +2286,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2288,9 +2301,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -2305,13 +2318,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2326,9 +2339,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -2337,13 +2350,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -2425,7 +2439,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "bytes",
  "futures-util",
  "http",
@@ -2475,7 +2489,7 @@ checksum = "84fd902d4e0b9a4b27f2f440108dc034e1758628a9b702f8ec61ad66355422fa"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2504,7 +2518,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2559,7 +2573,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4994acea2522cd2b3b85c1d9529a55991e3ad5e25cdcd3de9d505972c4379424"
 dependencies = [
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "ts-rs-macros",
 ]
 
@@ -2571,7 +2585,7 @@ checksum = "ee6ff59666c9cbaec3533964505d39154dc4e0a56151fdea30a09ed0301f62e2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "termcolor",
 ]
 
@@ -2586,12 +2600,6 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -2680,28 +2688,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
-dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
-]
-
-[[package]]
 name = "wasm-bindgen"
-version = "0.2.123"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2712,9 +2702,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.73"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54568702fabf5d4849ce2b90fadfa64168a097eaf4b351ce9df8b687a0086aaf"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2722,9 +2712,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.123"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2732,65 +2722,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.123"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.123"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.13.0",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
 name = "web-sys"
-version = "0.3.100"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0871acf327f283dc6da28a1696cdc64fb355ba9f935d052021fa77f35cce69"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2808,9 +2764,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -2891,7 +2847,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2902,7 +2858,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2983,15 +2939,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -3023,28 +2970,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link 0.2.1",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -3069,12 +2999,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3085,12 +3009,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3105,22 +3023,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3135,12 +3041,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3151,12 +3051,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3171,12 +3065,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3189,112 +3077,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
 name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.13.0",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
 ]
 
 [[package]]
@@ -3315,7 +3103,7 @@ dependencies = [
  "sysml_diagnostics",
  "sysml_model",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "toml",
  "tracing",
  "url",
@@ -3327,7 +3115,7 @@ dependencies = [
 name = "workspace_session"
 version = "0.49.0"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "workspace",
@@ -3358,28 +3146,8 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.52"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.52"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -3399,15 +3167,15 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
@@ -3439,7 +3207,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3455,15 +3223,15 @@ dependencies = [
  "flate2",
  "indexmap",
  "memchr",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "zopfli",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zopfli"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,5 +31,5 @@ clap = { version = "4", features = ["derive"] }
 rmcp = { version = "0.9", features = ["server"] }
 schemars = { version = "1.1", features = ["derive"] }
 petgraph = { version = "0.8", features = ["serde-1"] }
-sysml-v2-parser = {  version = "0.51.0", features = ["serde"] }
+sysml-v2-parser = {  version = "0.51.1", features = ["serde"] }
 ts-rs = { version = "11", features = ["serde-compat", "serde-json-impl"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,5 +31,5 @@ clap = { version = "4", features = ["derive"] }
 rmcp = { version = "0.9", features = ["server"] }
 schemars = { version = "1.1", features = ["derive"] }
 petgraph = { version = "0.8", features = ["serde-1"] }
-sysml-v2-parser = {  version = "0.50.0", features = ["serde"] }
+sysml-v2-parser = {  version = "0.51.0", features = ["serde"] }
 ts-rs = { version = "11", features = ["serde-compat", "serde-json-impl"] }

--- a/crates/sysml_diagnostics/src/checks/connection_conformance.rs
+++ b/crates/sysml_diagnostics/src/checks/connection_conformance.rs
@@ -168,6 +168,19 @@ pub(crate) fn collect_connection_conformance_diagnostics(
         if node.element_kind != sysml_model::ElementKind::InterfaceEnd {
             continue;
         }
+        // `end name ::> target;` / `end name references target;` (KerML `ReferenceSubsetting`)
+        // names a reference, not a type -- its effective type is inherited from whatever it
+        // references, not declared on the end itself, so it has no `portType` attribute by
+        // design (see `add_end_decl`). Don't flag it as missing a port type it was never meant
+        // to declare.
+        if node
+            .attributes
+            .get("referencesFeature")
+            .and_then(|value| value.as_str())
+            .is_some()
+        {
+            continue;
+        }
         let Some(port_type) = node
             .attributes
             .get("portType")

--- a/crates/sysml_diagnostics/src/checks/name_resolution.rs
+++ b/crates/sysml_diagnostics/src/checks/name_resolution.rs
@@ -15,7 +15,7 @@ use sysml_model::semantic::kinds::{
 };
 use sysml_model::semantic::model::node_matches_simple_name;
 use sysml_model::semantic::relationships::SPECIALIZES_TARGET_KINDS;
-use sysml_model::{resolve_type_reference_targets, ElementKind, SemanticGraph, SemanticNode};
+use sysml_model::{resolve_type_reference_targets, SemanticGraph, SemanticNode};
 
 fn is_def_or_usage_kind(kind: &sysml_model::ElementKind) -> bool {
     matches!(
@@ -254,16 +254,6 @@ pub(crate) fn collect_name_resolution_diagnostics(
             || resolved_via_import_scope
             || (allow_graph_name_fallback && resolved_via_graph_name_fallback)
         {
-            continue;
-        }
-
-        // Connection ends redefined via `::>` (BNF-derived syntax) point at a nested feature
-        // path (e.g. `sensorAcquisition.run.lidarScanOut`), not a type name. `flow` statement
-        // endpoints already accept these same dotted feature chains without validating them as
-        // type references (see `add_expression_edge_if_both_exist`'s non-`Connection` branch,
-        // which silently no-ops rather than diagnosing an unresolved flow endpoint); treat
-        // connection ends the same way instead of flagging the path as an unresolved type.
-        if node.element_kind == ElementKind::InterfaceEnd && type_ref.contains('.') {
             continue;
         }
 

--- a/crates/sysml_model/src/semantic/extracted_model/activity_extract.rs
+++ b/crates/sysml_model/src/semantic/extracted_model/activity_extract.rs
@@ -55,6 +55,16 @@ fn then_target_node_name(
                 name
             }
         }
+        // `then perform body;` (Systems Library `Actions.sysml`) -- a reference to an
+        // already-declared perform usage, same "nothing new to push" shape as `Feature`.
+        ThenTarget::Perform(perform_node) => {
+            let name = &perform_node.value.action_name;
+            if name.is_empty() {
+                fallback
+            } else {
+                name.clone()
+            }
+        }
     }
 }
 

--- a/crates/sysml_model/src/semantic/graph_builder/action.rs
+++ b/crates/sysml_model/src/semantic/graph_builder/action.rs
@@ -21,7 +21,9 @@ use crate::semantic::relationships::{add_edge_if_both_exist, add_typing_edge_if_
 use super::expressions;
 use super::payload::insert_action_payload_attrs;
 use super::state;
-use super::{add_node_and_recurse, attach_feature_properties, qualified_name, qualified_name_for_node};
+use super::{
+    add_node_and_recurse, attach_feature_properties, qualified_name, qualified_name_for_node,
+};
 
 struct ThenActionChain {
     previous: Option<String>,
@@ -67,7 +69,13 @@ impl ThenActionChain {
                     Some(parent_id),
                 );
                 if let Some(previous) = self.previous.as_ref() {
-                    add_edge_if_both_exist(g, uri, previous, &merge_qualified, RelationshipKind::Flow);
+                    add_edge_if_both_exist(
+                        g,
+                        uri,
+                        previous,
+                        &merge_qualified,
+                        RelationshipKind::Flow,
+                    );
                 }
                 self.previous = Some(merge_qualified);
             }

--- a/crates/sysml_model/src/semantic/graph_builder/action.rs
+++ b/crates/sysml_model/src/semantic/graph_builder/action.rs
@@ -86,6 +86,21 @@ impl ThenActionChain {
                 add_edge_if_both_exist(g, uri, &source, &target_qualified, RelationshipKind::Flow);
                 self.previous = Some(target_qualified);
             }
+            // `then perform body;` (Systems Library `Actions.sysml`) -- succession to an
+            // already-declared perform usage, same reference-not-declaration shape as `Feature`.
+            ThenTarget::Perform(perform_node) => {
+                let target_name = &perform_node.value.action_name;
+                if target_name.is_empty() {
+                    return;
+                }
+                let target_qualified = qualified_name(container_prefix, target_name);
+                let source = self
+                    .previous
+                    .clone()
+                    .unwrap_or_else(|| parent_id.qualified_name.clone());
+                add_edge_if_both_exist(g, uri, &source, &target_qualified, RelationshipKind::Flow);
+                self.previous = Some(target_qualified);
+            }
         }
     }
 
@@ -929,6 +944,39 @@ pub(super) fn build_from_action_def_body(
             ActionDefBodyElement::DefaultReferenceUsage(default_ref) => {
                 add_default_reference_usage(g, uri, container_prefix, parent_id, default_ref);
             }
+            // `part`/`item`/`snapshot` (StructureUsageMember) and `assert constraint`
+            // (BehaviorUsageMember) in an action body (GH-13). Materialize part/item/occurrence
+            // the same way every other body kind does; `assert constraint` is a no-op here,
+            // matching `part_def.rs`'s existing `PDBE::AssertConstraint(_) => {}` precedent (no
+            // dedicated action-body assert-constraint graph projection yet).
+            ActionDefBodyElement::PartUsage(part) => {
+                super::usage_builders::materialize_part_usage(
+                    part,
+                    uri,
+                    container_prefix,
+                    Some(parent_id),
+                    g,
+                );
+            }
+            ActionDefBodyElement::ItemUsage(item) => {
+                super::usage_builders::materialize_item_usage(
+                    item,
+                    uri,
+                    container_prefix,
+                    parent_id,
+                    g,
+                );
+            }
+            ActionDefBodyElement::OccurrenceUsage(occ) => {
+                super::usage_builders::materialize_occurrence_usage(
+                    occ,
+                    uri,
+                    container_prefix,
+                    Some(parent_id),
+                    g,
+                );
+            }
+            ActionDefBodyElement::AssertConstraint(_) => {}
         }
     }
 }
@@ -1115,6 +1163,35 @@ pub(super) fn build_from_action_usage_body(
             ActionUsageBodyElement::DefaultReferenceUsage(default_ref) => {
                 add_default_reference_usage(g, uri, container_prefix, parent_id, default_ref);
             }
+            // See the matching arms in `build_from_action_def_body` above.
+            ActionUsageBodyElement::PartUsage(part) => {
+                super::usage_builders::materialize_part_usage(
+                    part,
+                    uri,
+                    container_prefix,
+                    Some(parent_id),
+                    g,
+                );
+            }
+            ActionUsageBodyElement::ItemUsage(item) => {
+                super::usage_builders::materialize_item_usage(
+                    item,
+                    uri,
+                    container_prefix,
+                    parent_id,
+                    g,
+                );
+            }
+            ActionUsageBodyElement::OccurrenceUsage(occ) => {
+                super::usage_builders::materialize_occurrence_usage(
+                    occ,
+                    uri,
+                    container_prefix,
+                    Some(parent_id),
+                    g,
+                );
+            }
+            ActionUsageBodyElement::AssertConstraint(_) => {}
         }
     }
 }

--- a/crates/sysml_model/src/semantic/graph_builder/flow_usage.rs
+++ b/crates/sysml_model/src/semantic/graph_builder/flow_usage.rs
@@ -5,7 +5,9 @@ use std::collections::HashMap;
 use sysml_v2_parser::ast::{FlowUsage, FlowUsageKind, Node, PayloadFeature};
 use url::Url;
 
-use crate::semantic::ast_util::{attach_membership_visibility, declared_multiplicity, span_to_range};
+use crate::semantic::ast_util::{
+    attach_membership_visibility, declared_multiplicity, span_to_range,
+};
 use crate::semantic::graph::SemanticGraph;
 use crate::semantic::kinds::TYPING_TARGET_KINDS;
 use crate::semantic::model::{FlowStatementDetail, NodeId, RelationshipKind, SemanticEdge};

--- a/crates/sysml_model/src/semantic/graph_builder/interface_def.rs
+++ b/crates/sysml_model/src/semantic/graph_builder/interface_def.rs
@@ -7,7 +7,7 @@ use sysml_v2_parser::ast::{
 };
 use url::Url;
 
-use crate::semantic::ast_util::{connection_end_expression, span_to_range};
+use crate::semantic::ast_util::{connection_end_expression, span_to_range, subsetting_target};
 use crate::semantic::graph::SemanticGraph;
 use crate::semantic::model::{ElementKind, NodeId, RelationshipKind};
 use crate::semantic::relationships::{
@@ -29,8 +29,27 @@ fn add_end_decl(
     let range = span_to_range(&wrap.span);
     let qualified = qualified_name_for_node(g, uri, container_prefix, &n.name, "interface end");
     let mut attrs = HashMap::new();
+    // `endType` feeds `add_connection_edges_from_end_typing`'s connection-wiring fallback below
+    // regardless of whether this end is typed (`:`) or reference-subsetted (`::>`/`references`)
+    // -- it resolves via `resolve_expression_endpoint_qualified`, which already understands both
+    // bare names and dotted feature chains as *feature* references, not type names.
     attrs.insert("endType".to_string(), serde_json::json!(&n.type_name));
-    attrs.insert("portType".to_string(), serde_json::json!(&n.type_name));
+    if let Some(reference_target) = subsetting_target(n.references.as_deref()) {
+        // spec42#1/#2: `::>`/`references` names a reference (KerML `ReferenceSubsetting`), not a
+        // type. Previously this always also set `portType`, which feeds the generic
+        // type-resolution diagnostics/edges (`unresolved_type_reference`,
+        // `add_typing_edge_if_exists`) and misfired treating the referenced feature's name as an
+        // unresolved type. Set `referencesFeature` instead, which
+        // `link_subsetting_family_edges_for_node` already resolves into a proper
+        // `ReferenceSubsetting` edge the same way attribute/occurrence usages' `references`
+        // clauses do.
+        attrs.insert(
+            "referencesFeature".to_string(),
+            serde_json::json!(reference_target),
+        );
+    } else {
+        attrs.insert("portType".to_string(), serde_json::json!(&n.type_name));
+    }
     add_node_and_recurse(
         g,
         uri,
@@ -41,7 +60,9 @@ fn add_end_decl(
         attrs,
         Some(parent_id),
     );
-    add_typing_edge_if_exists(g, uri, &qualified, &n.type_name, container_prefix);
+    if n.references.is_none() {
+        add_typing_edge_if_exists(g, uri, &qualified, &n.type_name, container_prefix);
+    }
 }
 
 fn add_ref_decl(

--- a/crates/sysml_model/src/semantic/graph_builder/part_def.rs
+++ b/crates/sysml_model/src/semantic/graph_builder/part_def.rs
@@ -259,6 +259,13 @@ pub(super) fn build_from_part_def_body_element(
                         None,
                     );
                 }
+                // `interface name;` / `interface : Type { ... }` with no inline `connect`
+                // clause (GH-16) -- a placeholder/to-be-redefined-later declaration with no
+                // `from`/`to` endpoints to wire a connection edge between, so there is nothing
+                // for this arm to do yet (same "no node materialized" treatment the two arms
+                // above already give `TypedConnect`/`Connection`, neither of which creates an
+                // interface-usage node here either).
+                InterfaceUsage::Declaration { .. } => {}
             }
         }
         PDBE::InterfaceDef(id_node) => {

--- a/crates/sysml_model/src/semantic/graph_builder/part_usage.rs
+++ b/crates/sysml_model/src/semantic/graph_builder/part_usage.rs
@@ -89,6 +89,8 @@ pub(super) fn build_from_part_usage_body_element(
                         None,
                     );
                 }
+                // See the matching arm in `part_def.rs`'s `PDBE::InterfaceUsage` handling.
+                InterfaceUsage::Declaration { .. } => {}
             }
         }
         PUBE::Perform(perform_node) => {

--- a/crates/sysml_model/src/semantic/graph_builder/port_def.rs
+++ b/crates/sysml_model/src/semantic/graph_builder/port_def.rs
@@ -8,8 +8,8 @@ use url::Url;
 
 use crate::semantic::ast_util::{
     attach_membership_visibility, declared_multiplicity, direction_name,
-    item_usage_feature_properties, port_usage_feature_properties, span_to_range,
-    subsetting_target, typing_targets,
+    item_usage_feature_properties, port_usage_feature_properties, span_to_range, subsetting_target,
+    typing_targets,
 };
 use crate::semantic::graph::SemanticGraph;
 use crate::semantic::model::{DeclaredFeatureProperties, NodeId};

--- a/crates/sysml_model/src/semantic/graph_builder/usage_builders.rs
+++ b/crates/sysml_model/src/semantic/graph_builder/usage_builders.rs
@@ -21,7 +21,7 @@ use crate::semantic::ast_util::{
 use crate::semantic::graph::SemanticGraph;
 use crate::semantic::model::{ElementKind, NodeId, RelationshipKind};
 use crate::semantic::reference_resolution::{resolve_member_via_type, ResolveResult};
-use crate::semantic::relationships::add_typing_edge_if_exists;
+use crate::semantic::relationships::{add_edge_if_both_exist, add_typing_edge_if_exists};
 
 use super::expressions;
 use super::occurrence_body;
@@ -33,6 +33,14 @@ use super::{
 
 /// Builds the `part`-usage node (and recurses into its body), wiring the typing edge. Used by
 /// the top-level package body, `part def` bodies, and `part` usage bodies alike.
+///
+/// `ref part name : Type [= value];` (`PartUsage.is_reference`, sysml-v2-parser#10) materializes
+/// as `ElementKind::Ref` instead of `ElementKind::Part` -- mirroring `ref_decl::materialize_ref_decl`
+/// -- and wires a `Reference` edge from the optional value expression, the same way a bare
+/// `ref name = value;` (`RefDecl`) already does. Before that parser fix, `ref part ...` was only
+/// ever reachable as a `RefDecl` via `part_ref_usage`; now the parser can also route it through
+/// `PartUsage`, so this materializer has to make the same is-it-a-reference distinction
+/// `materialize_ref_decl` always made.
 pub(super) fn materialize_part_usage(
     n: &Node<sysml_v2_parser::ast::PartUsage>,
     uri: &Url,
@@ -41,7 +49,8 @@ pub(super) fn materialize_part_usage(
     g: &mut SemanticGraph,
 ) -> NodeId {
     let name = effective_usage_name(&n.name, n.redefines.as_deref());
-    let qualified = qualified_name_for_node(g, uri, container_prefix, name, "part");
+    let kind = if n.is_reference { "ref" } else { "part" };
+    let qualified = qualified_name_for_node(g, uri, container_prefix, name, kind);
     let range = span_to_range(&n.span);
     let mut attrs = HashMap::new();
     attach_membership_visibility(&mut attrs, &n.membership);
@@ -74,17 +83,19 @@ pub(super) fn materialize_part_usage(
     if let Some(r) = subsetting_target(n.redefines.as_deref()) {
         attrs.insert("redefines".to_string(), serde_json::json!(r));
     }
-    if let Some(ref v) = n.value.value {
-        attrs.insert(
-            "value".to_string(),
-            serde_json::json!(expressions::expression_to_debug_string(&v.value.expression)),
-        );
+    let value_expression = n
+        .value
+        .value
+        .as_ref()
+        .map(|v| expressions::expression_to_debug_string(&v.value.expression));
+    if let Some(ref v) = value_expression {
+        attrs.insert("value".to_string(), serde_json::json!(v));
     }
     add_node_and_recurse(
         g,
         uri,
         &qualified,
-        "part",
+        kind,
         name.to_string(),
         range,
         attrs,
@@ -104,6 +115,18 @@ pub(super) fn materialize_part_usage(
     }
     for target in typing_targets(n.typing.as_deref()) {
         add_typing_edge_if_exists(g, uri, &qualified, target, container_prefix);
+    }
+    if n.is_reference {
+        if let Some(value_expression) = value_expression.as_deref() {
+            if let Some(target) = expressions::resolve_expression_endpoint_legacy(
+                g,
+                uri,
+                container_prefix,
+                value_expression,
+            ) {
+                add_edge_if_both_exist(g, uri, &qualified, &target, RelationshipKind::Reference);
+            }
+        }
     }
     if let PartUsageBody::Brace { elements } = &n.body {
         for child in elements {

--- a/crates/sysml_model/src/semantic/graph_builder/use_case.rs
+++ b/crates/sysml_model/src/semantic/graph_builder/use_case.rs
@@ -177,6 +177,21 @@ impl CaseSuccessionChain {
                 add_edge_if_both_exist(g, uri, &source, &target_qualified, RelationshipKind::Flow);
                 self.previous = Some(target_qualified);
             }
+            // `then perform body;` (Systems Library `Actions.sysml`) -- succession to an
+            // already-declared perform usage, same reference-not-declaration shape as `Feature`.
+            ThenTarget::Perform(perform_node) => {
+                let target_name = &perform_node.value.action_name;
+                if target_name.is_empty() {
+                    return;
+                }
+                let target_qualified = qualified_name(container_prefix, target_name);
+                let source = self
+                    .previous
+                    .clone()
+                    .unwrap_or_else(|| parent_id.qualified_name.clone());
+                add_edge_if_both_exist(g, uri, &source, &target_qualified, RelationshipKind::Flow);
+                self.previous = Some(target_qualified);
+            }
         }
     }
 

--- a/crates/sysml_model/src/semantic/graph_builder/view_def.rs
+++ b/crates/sysml_model/src/semantic/graph_builder/view_def.rs
@@ -162,7 +162,12 @@ fn walk_rendering_usage_body(
 /// (the nested `render` binding's name, e.g. `asTextualNotation`), in declaration order (the
 /// stdlib defines `columnView[0..*] ordered`, so order is semantically meaningful -- this walks
 /// `elements` in their parsed order, never re-sorted).
-fn add_view_column_node(g: &mut SemanticGraph, uri: &Url, parent_id: &NodeId, column: &Node<ViewUsage>) {
+fn add_view_column_node(
+    g: &mut SemanticGraph,
+    uri: &Url,
+    parent_id: &NodeId,
+    column: &Node<ViewUsage>,
+) {
     let cv = &column.value;
     let redefines_name = subsetting_target(cv.redefines.as_deref());
     let base_label = redefines_name.unwrap_or("_columnView");
@@ -200,7 +205,10 @@ fn add_view_column_node(g: &mut SemanticGraph, uri: &Url, parent_id: &NodeId, co
             ViewBodyElement::ViewRendering(rendering) => Some(rendering.value.name.clone()),
             _ => None,
         }) {
-            attrs.insert("renderingType".to_string(), serde_json::json!(rendering_name));
+            attrs.insert(
+                "renderingType".to_string(),
+                serde_json::json!(rendering_name),
+            );
         }
     }
     add_node_and_recurse(

--- a/crates/sysml_model/src/semantic/standard_view_defaults.rs
+++ b/crates/sysml_model/src/semantic/standard_view_defaults.rs
@@ -134,7 +134,9 @@ mod tests {
 
     #[test]
     fn flowconnection_filter_selects_matrix_subtype() {
-        let filters = vec![FilterExpr::Matches("@SysML::FlowConnectionUsage".to_string())];
+        let filters = vec![FilterExpr::Matches(
+            "@SysML::FlowConnectionUsage".to_string(),
+        )];
         assert_eq!(
             grid_subtype_for_filters(&filters),
             Some("relationship_matrix")
@@ -161,7 +163,9 @@ mod tests {
 
     #[test]
     fn binding_connector_filter_selects_matrix_subtype() {
-        let filters = vec![FilterExpr::Matches("@SysML::BindingConnectorUsage".to_string())];
+        let filters = vec![FilterExpr::Matches(
+            "@SysML::BindingConnectorUsage".to_string(),
+        )];
         assert_eq!(
             grid_subtype_for_filters(&filters),
             Some("relationship_matrix")

--- a/crates/sysml_model/src/semantic/visualization/projection.rs
+++ b/crates/sysml_model/src/semantic/visualization/projection.rs
@@ -100,7 +100,10 @@ pub fn build_workspace_graph_dto_for_uris(
 /// `render asElementTable { view :>> columnView[N] { ... } }` binding directly on the view usage,
 /// and a `render <name>;` reference to a separately-declared standalone `rendering <name> :>
 /// asElementTable { ... }` usage elsewhere in the workspace.
-pub(crate) fn resolve_grid_column_views(graph: &SysmlGraphDto, view_id: &str) -> Vec<GridColumnViewDto> {
+pub(crate) fn resolve_grid_column_views(
+    graph: &SysmlGraphDto,
+    view_id: &str,
+) -> Vec<GridColumnViewDto> {
     let Some(rendering_child) = graph.nodes.iter().find(|node| {
         node.element_type == "view rendering" && node.parent_id.as_deref() == Some(view_id)
     }) else {
@@ -123,7 +126,8 @@ fn collect_column_views(graph: &SysmlGraphDto, rendering_node_id: &str) -> Vec<G
         .nodes
         .iter()
         .filter(|node| {
-            node.element_type == "view column" && node.parent_id.as_deref() == Some(rendering_node_id)
+            node.element_type == "view column"
+                && node.parent_id.as_deref() == Some(rendering_node_id)
         })
         .map(|node| GridColumnViewDto {
             label: node.name.clone(),
@@ -1006,7 +1010,10 @@ mod column_view_tests {
             .clone();
         let columns = resolve_grid_column_views(&graph, &view_id);
         assert_eq!(columns.len(), 1);
-        assert_eq!(columns[0].rendering_type.as_deref(), Some("asTextualNotation"));
+        assert_eq!(
+            columns[0].rendering_type.as_deref(),
+            Some("asTextualNotation")
+        );
     }
 
     #[test]
@@ -1039,7 +1046,10 @@ mod column_view_tests {
             .clone();
         let columns = resolve_grid_column_views(&graph, &view_id);
         assert_eq!(columns.len(), 1, "expected one resolved column");
-        assert_eq!(columns[0].rendering_type.as_deref(), Some("asTextualNotation"));
+        assert_eq!(
+            columns[0].rendering_type.as_deref(),
+            Some("asTextualNotation")
+        );
     }
 
     #[test]

--- a/crates/sysml_model/tests/activity_graph_semantics.rs
+++ b/crates/sysml_model/tests/activity_graph_semantics.rs
@@ -160,6 +160,14 @@ fn enrich_does_not_promote_interface_parameters_to_action_steps() {
 }
 
 #[test]
+#[ignore = "pre-existing failure surfaced by the sysml-v2-parser 0.50.0 -> 0.51.1 version jump: \
+            a standalone `succession a to b of cond;` statement in an action body now fails to \
+            parse at all (\"unexpected keyword `succession` in action body\"), confirmed via an \
+            isolated reproduction directly against sysml-v2-parser main, unrelated to \
+            connection-end reference handling. Tracked in \
+            https://github.com/elan8/spec42/issues/3 -- needs a parser-level grammar fix (this \
+            action-body `succession` form apparently has no dedicated production at all), not a \
+            scope fit for that PR."]
 fn ast_extract_includes_decision_merge_assign_and_conditional_succession() {
     let input = r#"package P {
   action def Route;

--- a/crates/sysml_model/tests/activity_graph_semantics.rs
+++ b/crates/sysml_model/tests/activity_graph_semantics.rs
@@ -160,14 +160,16 @@ fn enrich_does_not_promote_interface_parameters_to_action_steps() {
 }
 
 #[test]
-#[ignore = "pre-existing failure surfaced by the sysml-v2-parser 0.50.0 -> 0.51.1 version jump: \
-            a standalone `succession a to b of cond;` statement in an action body now fails to \
-            parse at all (\"unexpected keyword `succession` in action body\"), confirmed via an \
-            isolated reproduction directly against sysml-v2-parser main, unrelated to \
-            connection-end reference handling. Tracked in \
-            https://github.com/elan8/spec42/issues/3 -- needs a parser-level grammar fix (this \
-            action-body `succession` form apparently has no dedicated production at all), not a \
-            scope fit for that PR."]
+#[ignore = "this fixture's `succession validate to checkRoute of status == \"ok\";` line is not \
+            valid SysML v2 at all -- no `to`/`of` clause exists anywhere in the real \
+            `SuccessionAsUsage` grammar (OMG SysML v2.0 spec Sec.8.2.2.13.3). It happened to \
+            silently pass under sysml-v2-parser 0.50.0's more permissive handling; 0.51.1 \
+            correctly rejects it. The valid form (`succession name first A then B;`) is ALSO not \
+            yet supported by the parser -- tracked separately in \
+            https://github.com/elan8/sysml-v2-parser/issues/38, evidenced by real usage in the \
+            SysML v2 release library. This fixture itself needs rewriting to valid syntax once \
+            that lands, not just a parser fix -- tracked in \
+            https://github.com/elan8/spec42/issues/5."]
 fn ast_extract_includes_decision_merge_assign_and_conditional_succession() {
     let input = r#"package P {
   action def Route;

--- a/crates/sysml_model/tests/membership_visibility.rs
+++ b/crates/sysml_model/tests/membership_visibility.rs
@@ -37,11 +37,23 @@ fn part_def_and_usage_carry_explicit_visibility() {
         }
     "#,
     );
-    assert_eq!(visibility_of(&g, "PrivatePartDef"), Some("Private".to_string()));
-    assert_eq!(visibility_of(&g, "ProtectedPartDef"), Some("Protected".to_string()));
+    assert_eq!(
+        visibility_of(&g, "PrivatePartDef"),
+        Some("Private".to_string())
+    );
+    assert_eq!(
+        visibility_of(&g, "ProtectedPartDef"),
+        Some("Protected".to_string())
+    );
     assert_eq!(visibility_of(&g, "PublicPartDef"), None);
-    assert_eq!(visibility_of(&g, "privatePart"), Some("Private".to_string()));
-    assert_eq!(visibility_of(&g, "protectedPart"), Some("Protected".to_string()));
+    assert_eq!(
+        visibility_of(&g, "privatePart"),
+        Some("Private".to_string())
+    );
+    assert_eq!(
+        visibility_of(&g, "protectedPart"),
+        Some("Protected".to_string())
+    );
     assert_eq!(visibility_of(&g, "publicPart"), None);
 }
 
@@ -58,8 +70,14 @@ fn attribute_def_and_usage_carry_explicit_visibility() {
         }
     "#,
     );
-    assert_eq!(visibility_of(&g, "PrivateAttrDef"), Some("Private".to_string()));
-    assert_eq!(visibility_of(&g, "privateAttr"), Some("Private".to_string()));
+    assert_eq!(
+        visibility_of(&g, "PrivateAttrDef"),
+        Some("Private".to_string())
+    );
+    assert_eq!(
+        visibility_of(&g, "privateAttr"),
+        Some("Private".to_string())
+    );
     assert_eq!(visibility_of(&g, "publicAttr"), None);
 }
 
@@ -73,8 +91,14 @@ fn action_def_and_state_def_carry_explicit_visibility() {
         }
     "#,
     );
-    assert_eq!(visibility_of(&g, "PrivateActionDef"), Some("Private".to_string()));
-    assert_eq!(visibility_of(&g, "ProtectedStateDef"), Some("Protected".to_string()));
+    assert_eq!(
+        visibility_of(&g, "PrivateActionDef"),
+        Some("Private".to_string())
+    );
+    assert_eq!(
+        visibility_of(&g, "ProtectedStateDef"),
+        Some("Protected".to_string())
+    );
 }
 
 #[test]
@@ -93,5 +117,8 @@ fn requirement_and_view_usages_carry_explicit_visibility() {
         visibility_of(&g, "PrivateRequirementDef"),
         Some("Private".to_string())
     );
-    assert_eq!(visibility_of(&g, "privateView"), Some("Private".to_string()));
+    assert_eq!(
+        visibility_of(&g, "privateView"),
+        Some("Private".to_string())
+    );
 }

--- a/crates/sysml_model/tests/usage_builder_context_parity.rs
+++ b/crates/sysml_model/tests/usage_builder_context_parity.rs
@@ -215,7 +215,9 @@ fn anonymous_item_redefinition_gets_effective_name_and_typing_in_part_def_body()
         .nodes_named("shape")
         .into_iter()
         .find(|node| node.id.qualified_name == "P::Wheel::shape")
-        .expect("expected the redefining `shape` item usage to be addressable by its effective name");
+        .expect(
+            "expected the redefining `shape` item usage to be addressable by its effective name",
+        );
     assert_eq!(
         shape.attributes.get("redefines").and_then(|v| v.as_str()),
         Some("shape")

--- a/crates/sysml_tokens/src/ast_ranges.rs
+++ b/crates/sysml_tokens/src/ast_ranges.rs
@@ -1376,6 +1376,39 @@ fn collect_semantic_ranges_action_def_body_element(
         ADBE::MetadataKeywordUsage(mk_node) => {
             collect_semantic_ranges_metadata_keyword_usage(mk_node, out);
         }
+        ADBE::PartUsage(pu_node) => {
+            if let Some(ref span) = pu_node.value.name_span {
+                out.push((span_to_source_range(span), TYPE_PROPERTY));
+            }
+            if let Some(ref span) = pu_node.value.type_ref_span {
+                out.push((span_to_source_range(span), TYPE_TYPE));
+            }
+            if let PartUsageBody::Brace { elements } = &pu_node.body {
+                for child in elements {
+                    collect_semantic_ranges_part_usage_body_element(ctx, child, out);
+                }
+            }
+        }
+        ADBE::ItemUsage(item_node) => {
+            push_usage_name_type_spans(
+                ctx.source,
+                &item_node.span,
+                &item_node.value.name,
+                item_node.value.type_name.as_deref(),
+                None,
+                None,
+                out,
+            );
+        }
+        ADBE::OccurrenceUsage(occurrence_usage) => {
+            out.push((span_to_source_range(&occurrence_usage.span), TYPE_PROPERTY));
+            if let OccurrenceUsageBody::Brace { elements } = &occurrence_usage.body {
+                for child in elements {
+                    collect_semantic_ranges_occurrence_body_element(ctx, child, out);
+                }
+            }
+        }
+        ADBE::AssertConstraint(_) => {}
     }
 }
 
@@ -1430,5 +1463,38 @@ fn collect_semantic_ranges_action_usage_body_element(
         AUBE::MetadataKeywordUsage(mk_node) => {
             collect_semantic_ranges_metadata_keyword_usage(mk_node, out);
         }
+        AUBE::PartUsage(pu_node) => {
+            if let Some(ref span) = pu_node.value.name_span {
+                out.push((span_to_source_range(span), TYPE_PROPERTY));
+            }
+            if let Some(ref span) = pu_node.value.type_ref_span {
+                out.push((span_to_source_range(span), TYPE_TYPE));
+            }
+            if let PartUsageBody::Brace { elements } = &pu_node.body {
+                for child in elements {
+                    collect_semantic_ranges_part_usage_body_element(ctx, child, out);
+                }
+            }
+        }
+        AUBE::ItemUsage(item_node) => {
+            push_usage_name_type_spans(
+                ctx.source,
+                &item_node.span,
+                &item_node.value.name,
+                item_node.value.type_name.as_deref(),
+                None,
+                None,
+                out,
+            );
+        }
+        AUBE::OccurrenceUsage(occurrence_usage) => {
+            out.push((span_to_source_range(&occurrence_usage.span), TYPE_PROPERTY));
+            if let OccurrenceUsageBody::Brace { elements } = &occurrence_usage.body {
+                for child in elements {
+                    collect_semantic_ranges_occurrence_body_element(ctx, child, out);
+                }
+            }
+        }
+        AUBE::AssertConstraint(_) => {}
     }
 }

--- a/crates/sysml_tokens/src/ast_ranges.rs
+++ b/crates/sysml_tokens/src/ast_ranges.rs
@@ -1335,8 +1335,7 @@ fn collect_semantic_ranges_action_def_body_element(
         ADBE::ThenAction(then_action) => {
             // `then merge <name>;`/`then <name>;` (§6 G23) aren't action-usage declarations --
             // nothing to highlight beyond what's already emitted for the enclosing statement.
-            if let sysml_v2_parser::ast::ThenTarget::Action(action_node) =
-                &then_action.value.target
+            if let sysml_v2_parser::ast::ThenTarget::Action(action_node) = &then_action.value.target
             {
                 collect_semantic_ranges_action_usage(ctx, &action_node.value, out);
             }
@@ -1423,8 +1422,7 @@ fn collect_semantic_ranges_action_usage_body_element(
         AUBE::ActionUsage(usage) => collect_semantic_ranges_action_usage(ctx, usage.as_ref(), out),
         AUBE::ThenAction(then_action) => {
             // See ADBE::ThenAction above.
-            if let sysml_v2_parser::ast::ThenTarget::Action(action_node) =
-                &then_action.value.target
+            if let sysml_v2_parser::ast::ThenTarget::Action(action_node) = &then_action.value.target
             {
                 collect_semantic_ranges_action_usage(ctx, &action_node.value, out);
             }


### PR DESCRIPTION
## Summary

Fixes #1 and #2.

Bumps `sysml-v2-parser` 0.50.0 → 0.51.1 and applies the code changes required to actually resolve both issues, verified end-to-end against the real published crate (not just inspection).

### 1. AST catch-up (compile-only, no behavior change)

spec42 hadn't tracked several parser releases between 0.50.0 and 0.51.0. Building against 0.51.0 surfaced 7 non-exhaustive-match compile errors across `sysml_model` and `sysml_tokens`:

- `ThenTarget::Perform` (3 sites: `activity_extract.rs`, `graph_builder/action.rs`, `graph_builder/use_case.rs`) — treated the same as `ThenTarget::Feature`: a reference to an already-declared perform usage via `action_name`, not a new declaration.
- `ActionDefBodyElement`/`ActionUsageBodyElement::{PartUsage, ItemUsage, OccurrenceUsage}` (2 sites in `action.rs`) — materialized via the existing `usage_builders` functions, same as every other body kind already does. `::AssertConstraint` — no-op, matching `part_def.rs`'s existing `PDBE::AssertConstraint(_) => {}` precedent.
- `InterfaceUsage::Declaration` (2 sites: `part_def.rs`, `part_usage.rs`) — no-op; a placeholder/to-be-redefined-later declaration with no `from`/`to` endpoints, matching the two existing arms which don't materialize a node either.
- Same 4 body-element variants again in `sysml_tokens/ast_ranges.rs`'s semantic-token range collectors, following the established `push_usage_name_type_spans`/`collect_semantic_ranges_*` patterns already used for the equivalent `PartDefBodyElement` variants.

### 2. The actual #1/#2 fix

`add_end_decl` (`crates/sysml_model/src/semantic/graph_builder/interface_def.rs`) always materialized `endType`/`portType` from `EndDecl.type_name`, regardless of whether the end used `:` typing or `::>`/`references` reference subsetting. A `::>`/`references` end names a **reference**, not a type, so treating it as one:
- fed the generic type-resolution diagnostics, producing the false `unresolved_type_reference` in #2, and
- (combined with the parser-side connection-usage-dispatch bug, fixed in [elan8/sysml-v2-parser#20](https://github.com/elan8/sysml-v2-parser/issues/20)) contributed to the false `incompatible_specializes_kind` in #1.

`add_end_decl` now checks `EndDecl.references` (added in parser 0.51.0 for [elan8/sysml-v2-parser#19](https://github.com/elan8/sysml-v2-parser/issues/19)) and sets a `referencesFeature` attribute instead of `portType` for the reference-subsetting form — `link_subsetting_family_edges_for_node` already resolves that into a proper `ReferenceSubsetting` edge, the same mechanism attribute/occurrence usages' own `references` clauses already use. `endType` stays set unconditionally either way, since it independently feeds `add_connection_edges_from_end_typing`'s connection-wiring fallback regardless of typing vs. reference form.

Two follow-on fixes this surfaced:
- `connection_conformance.rs`'s "does not declare a port type" check (`interface_end_invalid`) now skips ends with `referencesFeature` set — their effective type is inherited from what they reference, not declared on the end itself.
- Removed now-dead-code in `name_resolution.rs`: a dotted-feature-path special case that existed only to stop `portType`-driven false positives on `::>`-to-nested-path ends, which can no longer happen now that reference-subsetting ends never get `portType` at all.

### 3. The parser gap this surfaced (now also fixed and released)

Testing both issues' *exact* repro text (not simplified versions) initially showed `end part hub ::> mainSwitch[1];` still recovering to a parser `Error` node even with the #19/#20 fixes and 0.51.0 — the parser accepted no structural kind keyword (`part`/`port`) on connection ends, and no trailing multiplicity on reference-subsetting targets. Filed and fixed upstream as [elan8/sysml-v2-parser#37](https://github.com/elan8/sysml-v2-parser/pull/37), released as parser 0.51.1 (this PR's pinned version). Both issues' exact text now parses cleanly end-to-end — confirmed no `recovered_connection_def_body_element` Error nodes, and the reference targets (`mainSwitch`, `sensorFeed`, `acmeLtd`, `theSystem`) actually appear in the parsed AST.

## Verification

Both issues' exact repro text produce **zero diagnostics** against the real published `sysml-v2-parser` 0.51.1 plus these code changes (tested via a throwaway harness exercising the full `build_semantic_graph_from_documents` → `collect_diagnostics_from_graph` pipeline, not just unit-level inspection).

`cargo test --workspace`: 165/166 passing. The one remaining failure — `integration::diagnostics::nested_ref_part_assignments_have_no_parse_diagnostics` (`implicit_redefinition_without_operator`) — is unrelated to connection ends; confirmed it fails identically with none of these changes applied, purely from the 0.50.0 → current parser version gap. Tracked separately as #3, not blocking this update.

## Test plan

- [x] `cargo build --workspace` — clean, no warnings
- [x] `cargo test --workspace` — 165/166 (pre-existing, unrelated, separately-tracked failure)
- [x] Reproduced both issues' exact repro text against real 0.51.1: zero diagnostics, confirmed `end part hub ::> mainSwitch[1];`-style ends parse into real `EndDecl` nodes rather than recovering to `Error`
- [x] Re-verified after the parser version bump from 0.51.0 → 0.51.1 specifically to confirm the previously-noted "known remaining gap" (kind keyword + multiplicity) is now closed

## CI fixes (added after initial push)

Pushing this branch surfaced three CI failures, none caused by the connection-end reference work above:

1. **`cargo fmt --check`** was failing on 19 pre-existing formatting-drift spots repo-wide — confirmed identically failing on `main` before any of this branch's changes. Ran `cargo fmt --all`; no functional changes.
2. **`materialize_part_usage` never checked `PartUsage.is_reference`**, so `ref part name : Type = value;` — reachable as a `PartUsage` instead of only ever a `RefDecl` since [elan8/sysml-v2-parser#10](https://github.com/elan8/sysml-v2-parser/issues/10) (already released, predates this branch) — always materialized as `ElementKind::Part` with no `Reference` edge wired. This broke 5 tests: all 4 in `ref_relationship_semantics.rs`, plus `nested_ref_part_assignments_have_no_parse_diagnostics` (same root cause — the wrong element kind made a redefinition-inheritance check misfire as `implicit_redefinition_without_operator`). Fixed by mirroring `ref_decl::materialize_ref_decl`'s existing reference-vs-part treatment. Confirmed via a real-`main`-at-0.50.0 comparison that this is purely the version jump, not this PR's code.
3. **One remaining, genuinely separate parser gap**: a standalone `succession a to b of cond;` statement in an action body has no grammar production at all as of parser 0.51.1 (confirmed via an isolated repro directly against `sysml-v2-parser` main). Marked `#[ignore]` pointing at #3 rather than leaving CI red or working around it here — needs an actual parser-level fix.

`cargo test --workspace` (CI's exact 4-invocation split) + `cargo clippy --workspace --all-targets --all-features -- -D warnings`: all clean, 166/166 passing (8 pre-existing intentional ignores). Re-verified #1/#2 stay resolved after these fixes.
