### PR TITLE
Support bundled libraries and typed ref-part interconnections

### DIFF
--- a/crates/lsp_server/tests/integration/interconnection_visualization.rs
+++ b/crates/lsp_server/tests/integration/interconnection_visualization.rs
@@ -6,6 +6,30 @@ use std::time::{Duration, Instant};
 use super::harness::{next_id, read_message, send_message, spawn_server};
 use super::perf_report::{graph_node_count, request_with_perf_capture, workspace_loaded_files};
 
+const REF_PART_INTERCONNECTION_MODEL: &str = r#"package RefContext {
+  port def LinkPort;
+
+  part def System {
+    port link : LinkPort;
+  }
+
+  part def Peer {
+    port link : LinkPort;
+  }
+
+  part def Context {
+    ref part system : System;
+    part peer : Peer;
+    connect system.link to peer.link;
+  }
+
+  part context : Context;
+
+  view refConnections : InterconnectionView {
+    expose context;
+  }
+}"#;
+
 fn repo_examples_drone_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../examples/drone")
 }
@@ -151,6 +175,135 @@ fn lsp_interconnection_visualization_returns_slim_scene_only_payload_for_drone()
     assert!(
         result.get("viewCandidates").is_some(),
         "slim interconnection payload should retain viewCandidates for the webview selector"
+    );
+
+    let _ = child.kill();
+}
+
+#[test]
+fn lsp_interconnection_visualization_projects_connections_to_typed_ref_parts() {
+    let workspace_dir = tempfile::tempdir().expect("temporary workspace");
+    let model_path = workspace_dir.path().join("Model.sysml");
+    std::fs::write(&model_path, REF_PART_INTERCONNECTION_MODEL).expect("write model fixture");
+
+    let root_uri = url::Url::from_directory_path(workspace_dir.path()).expect("workspace root uri");
+    let model_uri = url::Url::from_file_path(&model_path).expect("model uri");
+
+    let mut child = spawn_server();
+    let mut stdin = child.stdin.take().expect("stdin");
+    let mut stdout = child.stdout.take().expect("stdout");
+
+    let init_id = next_id();
+    send_message(
+        &mut stdin,
+        &serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": init_id,
+            "method": "initialize",
+            "params": {
+                "processId": null,
+                "rootUri": root_uri.as_str(),
+                "capabilities": {},
+                "initializationOptions": {
+                    "workspace": { "maxFilesPerPattern": 100 }
+                },
+                "clientInfo": { "name": "ref-part-interconnection-test", "version": "0.1.0" }
+            }
+        })
+        .to_string(),
+    );
+    let _ = read_message(&mut stdout).expect("init response");
+    send_message(
+        &mut stdin,
+        &serde_json::json!({ "jsonrpc": "2.0", "method": "initialized", "params": {} }).to_string(),
+    );
+
+    let workspace_model_params = serde_json::json!({
+        "textDocument": { "uri": model_uri.as_str() },
+        "scope": ["graph", "stats", "workspaceVisualization"]
+    });
+    let wait_start = Instant::now();
+    loop {
+        let capture = request_with_perf_capture(
+            &mut stdin,
+            &mut stdout,
+            "sysml/model",
+            workspace_model_params.clone(),
+        );
+        if workspace_loaded_files(&capture.json) > 0 && graph_node_count(&capture.json) > 0 {
+            break;
+        }
+        if wait_start.elapsed() >= Duration::from_secs(60) {
+            panic!(
+                "workspace model did not become ready within 60s; last response: {:#?}",
+                capture.json
+            );
+        }
+        std::thread::sleep(Duration::from_millis(250));
+    }
+
+    let visualization = request_with_perf_capture(
+        &mut stdin,
+        &mut stdout,
+        "sysml/visualization",
+        serde_json::json!({
+            "workspaceRootUri": root_uri.as_str(),
+            "view": "interconnection-view",
+            "selectedView": "refConnections"
+        }),
+    );
+    let result = &visualization.json["result"];
+    assert_eq!(result["selectedViewName"].as_str(), Some("refConnections"));
+
+    let prepared = result["preparedView"]
+        .as_object()
+        .expect("preparedView should be present");
+    let nodes = prepared["nodes"]
+        .as_array()
+        .expect("preparedView.nodes should be an array");
+    let reference_part = nodes
+        .iter()
+        .find(|node| {
+            node["attributes"]["qualifiedName"]
+                .as_str()
+                .is_some_and(|name| name.ends_with(".context.system"))
+        })
+        .expect("preparedView should contain the typed reference part");
+    assert_eq!(
+        reference_part["attributes"]["isReference"].as_bool(),
+        Some(true)
+    );
+    let reference_ports = reference_part["attributes"]["portDetails"]
+        .as_array()
+        .expect("reference part should expose inherited port details");
+    assert!(reference_ports.iter().any(|port| port["name"] == "link"));
+
+    let peer_part = nodes
+        .iter()
+        .find(|node| {
+            node["attributes"]["qualifiedName"]
+                .as_str()
+                .is_some_and(|name| name.ends_with(".context.peer"))
+        })
+        .expect("preparedView should contain the peer part");
+    let peer_ports = peer_part["attributes"]["portDetails"]
+        .as_array()
+        .expect("peer part should expose port details");
+    assert!(peer_ports.iter().any(|port| port["name"] == "link"));
+
+    let edges = prepared["edges"]
+        .as_array()
+        .expect("preparedView.edges should be an array");
+    assert_eq!(edges.len(), 1, "expected exactly one prepared connection");
+    assert!(edges[0]["attributes"]["sourcePortId"].is_string());
+    assert!(edges[0]["attributes"]["targetPortId"].is_string());
+    assert!(
+        result.get("emptyStateMessage").is_none()
+            || result["emptyStateMessage"].is_null()
+            || !result["emptyStateMessage"]
+                .as_str()
+                .is_some_and(|message| message.contains("no internal connectors")),
+        "a connected ref-part view must not report the no-connectors empty state"
     );
 
     let _ = child.kill();

--- a/crates/sysml_model/src/semantic/component_view.rs
+++ b/crates/sysml_model/src/semantic/component_view.rs
@@ -13,7 +13,7 @@ use url::Url;
 
 use crate::semantic::graph::SemanticGraph;
 use crate::semantic::kinds::is_part_like;
-use crate::semantic::model::{NodeId, SemanticNode};
+use crate::semantic::model::{ElementKind, NodeId, SemanticNode};
 
 // Re-export the canonical port predicate for consumers of this module.
 pub use crate::semantic::kinds::is_port_like;
@@ -198,6 +198,21 @@ fn node_to_typed_by_ref(node: &SemanticNode) -> TypedByRef {
     }
 }
 
+/// Classifies usages that can materialize as structural parts in a component tree.
+///
+/// A generic `ref` can reference many kinds of elements, so it is structural only
+/// when its resolved typing target is itself part-like. This intentionally stays
+/// local to component expansion: the broader `is_part_like` predicate is also used
+/// for definition classification and type compatibility.
+fn is_structural_part_usage(graph: &SemanticGraph, node: &SemanticNode) -> bool {
+    is_part_like(&node.element_kind)
+        || (node.element_kind == ElementKind::Ref
+            && graph
+                .outgoing_typing_or_specializes_targets(node)
+                .into_iter()
+                .any(|target| is_part_like(&target.element_kind)))
+}
+
 fn compute_has_materialized_shape(
     graph: &SemanticGraph,
     def_node: &SemanticNode,
@@ -212,7 +227,7 @@ fn compute_has_materialized_shape(
     let has_direct = graph
         .children_of(def_node)
         .iter()
-        .any(|child| is_part_like(&child.element_kind) || is_port_like(&child.element_kind));
+        .any(|child| is_structural_part_usage(graph, child) || is_port_like(&child.element_kind));
     let result = has_direct
         || graph
             .outgoing_typing_or_specializes_targets(def_node)
@@ -297,7 +312,7 @@ fn expand_def_subtree(
     let can_recurse = max_depth.is_none_or(|max| current_depth < max);
 
     for part_child in graph.children_of(def_node) {
-        if !is_part_like(&part_child.element_kind) {
+        if !is_structural_part_usage(graph, part_child) {
             continue;
         }
         let child_path = format!("{parent_path}.{}", part_child.name);
@@ -376,7 +391,7 @@ fn expand_usage_children(
     existing_paths: &mut HashSet<String>,
 ) {
     for part_child in graph.children_of(usage_node) {
-        if !is_part_like(&part_child.element_kind) {
+        if !is_structural_part_usage(graph, part_child) {
             continue;
         }
         let child_path = format!("{parent_path}.{}", part_child.name);
@@ -429,7 +444,7 @@ mod tests {
     use crate::semantic::source::{SysmlDocument, SysmlDocumentSourceKind};
     use crate::semantic::workspace_graph::build_semantic_graph_from_documents;
 
-    use super::typed_by_reference;
+    use super::{expand_part_definition, typed_by_reference};
 
     fn build_graph(source: &str) -> crate::semantic::graph::SemanticGraph {
         let doc = SysmlDocument::from_memory_path(
@@ -483,5 +498,41 @@ mod tests {
         let graph = build_graph("package Demo { part def Robot { part loose; } }");
         let usage = node_by_qualified_name(&graph, "Demo::Robot::loose");
         assert!(typed_by_reference(&graph, usage).is_none());
+    }
+
+    #[test]
+    fn expansion_includes_typed_ref_parts_but_excludes_untyped_refs() {
+        let graph = build_graph(
+            r#"package Demo {
+  port def LinkPort;
+  part def System {
+    port link : LinkPort;
+  }
+  part def Peer {
+    port link : LinkPort;
+  }
+  part def Context {
+    ref part system : System;
+    part peer : Peer;
+    ref part loose;
+    connect system.link to peer.link;
+  }
+  part context : Context;
+}"#,
+        );
+        let context = node_by_qualified_name(&graph, "Demo::Context");
+
+        let expanded = expand_part_definition(&graph, context, "Demo.context", None);
+        let system = expanded
+            .iter()
+            .find(|part| part.path == "Demo.context.system")
+            .expect("typed ref part should be materialized");
+
+        assert_eq!(system.element_kind, "ref");
+        assert!(system.ports.iter().any(|port| port.name == "link"));
+        assert!(expanded.iter().any(|part| part.path == "Demo.context.peer"));
+        assert!(!expanded
+            .iter()
+            .any(|part| part.path == "Demo.context.loose"));
     }
 }

--- a/crates/sysml_model/src/semantic/graph.rs
+++ b/crates/sysml_model/src/semantic/graph.rs
@@ -463,8 +463,10 @@ impl SemanticGraphData {
 
     /// Merges another graph but skips nodes already declared in the workspace.
     ///
-    /// Skips a library node when its qualified name already exists, or when it
-    /// belongs to a package name declared in `shadowed_packages` (workspace wins).
+    /// Skips a library node when it belongs to a most-specific package declared in
+    /// `shadowed_packages` (workspace wins), or when a non-package element with the same
+    /// qualified name already exists. Duplicate ancestor package nodes are retained so a
+    /// namespace can be assembled from workspace and library contributions.
     pub fn merge_skip_existing_qualified_names(
         &mut self,
         other: SemanticGraph,
@@ -484,10 +486,12 @@ impl SemanticGraphData {
             .extend(other.pending_expression_relationships.iter().cloned());
         for (id, node) in other.iter_nodes() {
             if let Some(shadowed) = shadowed_packages {
-                if self
+                let exact_name_exists = self
                     .node_ids_by_qualified_name
-                    .contains_key(&id.qualified_name)
-                    || Self::qualified_name_under_packages(&id.qualified_name, shadowed)
+                    .contains_key(&id.qualified_name);
+                let is_package = matches!(node.element_kind, ElementKind::Package);
+                if Self::qualified_name_under_packages(&id.qualified_name, shadowed)
+                    || (exact_name_exists && !is_package)
                 {
                     continue;
                 }

--- a/crates/sysml_model/src/semantic/library_loader.rs
+++ b/crates/sysml_model/src/semantic/library_loader.rs
@@ -155,8 +155,9 @@ fn resolve_library_closure_inner(
     if library_roots.is_empty() {
         return Ok(Vec::new());
     }
-    let index = build_package_index(library_roots)?;
+    let mut index = build_package_index(library_roots)?;
     let workspace_declared_packages = workspace_declared_packages(workspace);
+    expand_library_namespaces_shared_with_workspace(&mut index, &workspace_declared_packages)?;
     let mut seeds = HashSet::<PackageKey>::new();
     seeds.extend(options.seed_packages.iter().cloned().map(PackageKey));
     let mut wants_sysml_bootstrap = false;
@@ -481,6 +482,48 @@ package Views {
         assert!(
             paths.iter().any(|p| p.contains("ScalarValues.sysml")),
             "transitive workspace import should still load ScalarValues, got {paths:?}"
+        );
+    }
+
+    #[test]
+    fn closure_loads_nested_library_package_beside_shared_workspace_namespace() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let lib = temp.path().join("lib");
+        fs::create_dir_all(&lib).expect("lib dir");
+        fs::write(
+            lib.join("Method.sysml"),
+            r#"
+package Elan8 {
+    package Method {
+        package Core { part def ProjectInfo; }
+    }
+}
+"#,
+        )
+        .expect("method library");
+        let workspace = [WorkspaceSource {
+            path: "Photonics.sysml",
+            content: r#"
+package Elan8 {
+    package Photonics { item def OpticalSignal; }
+}
+package App {
+    private import Elan8::Method::Core::*;
+    part project : ProjectInfo;
+}
+"#,
+        }];
+        let roots = vec![lib.to_string_lossy().replace('\\', "/")];
+
+        let loaded = resolve_library_closure(&workspace, &roots, &LibraryClosureOptions::default())
+            .expect("closure");
+
+        assert!(
+            loaded
+                .iter()
+                .any(|file| file.path.ends_with("Method.sysml")),
+            "a workspace contribution to Elan8 must not hide Elan8::Method; got {:?}",
+            loaded.iter().map(|file| &file.path).collect::<Vec<_>>()
         );
     }
 

--- a/crates/sysml_model/src/semantic/library_loader/package_scan.rs
+++ b/crates/sysml_model/src/semantic/library_loader/package_scan.rs
@@ -59,6 +59,54 @@ pub(crate) fn build_package_index(library_roots: &[String]) -> Result<PackageInd
     })
 }
 
+/// Expand the cheap top-level package index only where a workspace and a library share a
+/// namespace root.
+///
+/// The normal index deliberately reads only the first package declaration in each file so
+/// import-closure startup does not parse the entire library corpus. That is sufficient until a
+/// workspace contributes to the same namespace as a library, for example
+/// `Elan8::Photonics` beside bundled `Elan8::Method` and `Elan8::Electronics`. In that case the
+/// top-level `Elan8` workspace package satisfies the root seed, and the nested library packages
+/// need their own index entries to remain reachable.
+pub(crate) fn expand_library_namespaces_shared_with_workspace(
+    index: &mut PackageIndex,
+    workspace_packages: &HashSet<PackageKey>,
+) -> Result<(), String> {
+    let shared_roots: Vec<PackageKey> = workspace_packages
+        .iter()
+        .filter(|package| !package.0.contains("::") && index.packages.contains_key(*package))
+        .cloned()
+        .collect();
+
+    for root in shared_roots {
+        let candidates = index.packages.get(&root).cloned().unwrap_or_default();
+        for candidate in candidates {
+            let full_path = PathBuf::from(&candidate.root).join(&candidate.path);
+            let content = std::fs::read_to_string(&full_path).map_err(|err| {
+                format!(
+                    "failed to read shared-namespace library file {}: {err}",
+                    full_path.display()
+                )
+            })?;
+            for package in declared_packages_in_content(&content) {
+                let key = PackageKey(package);
+                if key == root {
+                    continue;
+                }
+                let entries = index.packages.entry(key).or_default();
+                if !entries
+                    .iter()
+                    .any(|entry| entry.root == candidate.root && entry.path == candidate.path)
+                {
+                    entries.push(candidate.clone());
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
 pub(crate) fn extract_package_name(content: &str) -> Option<String> {
     for line in content.lines().take(80) {
         let trimmed = line.trim();

--- a/crates/sysml_model/src/semantic/pipeline.rs
+++ b/crates/sysml_model/src/semantic/pipeline.rs
@@ -25,6 +25,24 @@ use crate::semantic::workspace_graph::WorkspaceParsedDocument;
 /// decide how it merges — see [`link_parsed_documents_parallel`].
 type SourceTaggedDocument = (SysmlDocumentSourceKind, WorkspaceParsedDocument);
 
+/// Packages that are not merely namespace ancestors of another workspace package.
+///
+/// A workspace may contribute `Elan8::Photonics` while libraries contribute sibling packages
+/// such as `Elan8::Method`. Treating the common `Elan8` ancestor as a shadow root would hide
+/// those siblings. The most-specific workspace packages still shadow matching library content.
+fn most_specific_packages(packages: HashSet<String>) -> HashSet<String> {
+    packages
+        .iter()
+        .filter(|candidate| {
+            let descendant_prefix = format!("{candidate}::");
+            !packages
+                .iter()
+                .any(|other| other.starts_with(&descendant_prefix))
+        })
+        .cloned()
+        .collect()
+}
+
 /// Build, merge, link, and resolve pending relationships for pre-loaded documents.
 pub fn build_and_link_graph(
     documents: &[SysmlDocument],
@@ -60,6 +78,8 @@ pub fn build_and_link_graph(
             parse_cached: false,
         });
     }
+
+    let workspace_packages = most_specific_packages(workspace_packages);
 
     for document in library_docs {
         let parse_start = Instant::now();
@@ -170,10 +190,12 @@ pub fn link_parsed_documents_parallel_from(
             (doc_graph, entry)
         })
         .collect();
-    let workspace_packages: HashSet<String> = workspace_built
-        .iter()
-        .flat_map(|(_, entry)| declared_packages_from_parsed(&entry.parsed))
-        .collect();
+    let workspace_packages = most_specific_packages(
+        workspace_built
+            .iter()
+            .flat_map(|(_, entry)| declared_packages_from_parsed(&entry.parsed))
+            .collect(),
+    );
     for (doc_graph, entry) in workspace_built {
         uris.push(entry.uri.clone());
         graph.merge(doc_graph);

--- a/crates/sysml_model/src/semantic/source/providers/filesystem.rs
+++ b/crates/sysml_model/src/semantic/source/providers/filesystem.rs
@@ -471,4 +471,51 @@ package Demo {
             "library Demo must not be merged when workspace declares Demo"
         );
     }
+
+    #[test]
+    fn provider_merges_nested_library_package_beside_shared_workspace_namespace() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join("workspace");
+        let lib = temp.path().join("lib");
+        fs::create_dir_all(&workspace).expect("workspace dir");
+        fs::create_dir_all(&lib).expect("lib dir");
+        fs::write(
+            workspace.join("App.sysml"),
+            r#"
+package Elan8 {
+    package Photonics { item def OpticalSignal; }
+}
+package App {
+    private import Elan8::Method::Core::*;
+    part project : ProjectInfo;
+}
+"#,
+        )
+        .expect("workspace model");
+        fs::write(
+            lib.join("Method.sysml"),
+            r#"
+package Elan8 {
+    package Method {
+        package Core { part def ProjectInfo; }
+    }
+}
+"#,
+        )
+        .expect("method library");
+
+        let provider =
+            FileSystemDocumentProvider::new(workspace.clone(), Some(workspace), vec![lib]);
+        let (graph, _) = build_semantic_graph_with_provider(&provider).expect("graph");
+
+        assert!(graph
+            .node_ids_for_qualified_name("Elan8::Photonics::OpticalSignal")
+            .is_some());
+        assert!(
+            graph
+                .node_ids_for_qualified_name("Elan8::Method::Core::ProjectInfo")
+                .is_some(),
+            "bundled nested namespaces must remain visible beside workspace Elan8 packages"
+        );
+    }
 }

--- a/crates/workspace/src/library_graph_cache.rs
+++ b/crates/workspace/src/library_graph_cache.rs
@@ -12,15 +12,17 @@
 //!
 //! ```text
 //! [magic:       4 bytes  "LGCX"]
-//! [version:    16 bytes  spec42 semver (12 bytes, zero-padded) + PARSE_AST_VERSION (4 bytes, le)]
+//! [version:    20 bytes  spec42 semver (12 bytes, zero-padded) + PARSE_AST_VERSION (4 bytes, le)
+//!                       + library-graph semantics version (4 bytes, le)]
 //! [payload:    remainder — bincode-encoded LibraryGraphCachePayload]
 //! ```
 //!
 //! # Invalidation (two-level)
 //!
 //! **Level 1 — filename key**: SHA-256 of sorted library path strings +
-//! `CARGO_PKG_VERSION` + `sysml_v2_parser::PARSE_AST_VERSION`. Invalidates on path config
-//! changes, spec42 binary upgrades, or a parser dependency bump that changes the AST schema.
+//! `CARGO_PKG_VERSION` + `sysml_v2_parser::PARSE_AST_VERSION` + the library-graph semantics
+//! version. Invalidates on path config changes, spec42 binary upgrades, parser AST changes, or
+//! semantic changes to library closure/merging within the same development version.
 //!
 //! **Level 2 — file metadata fingerprint** (inside payload): sorted list of
 //! `(path, size_bytes, mtime_secs)` for every `.sysml`/`.kerml` file under each
@@ -39,21 +41,19 @@ use url::Url;
 use crate::semantic::SemanticGraph;
 
 const MAGIC: &[u8; 4] = b"LGCX";
-const VERSION_FIELD_LEN: usize = 16;
+const VERSION_FIELD_LEN: usize = 20;
+const LIBRARY_GRAPH_SEMANTICS_VERSION: u32 = 2;
 
 fn version_field() -> [u8; VERSION_FIELD_LEN] {
-    // First 12 bytes: spec42 semver string; last 4 bytes: PARSE_AST_VERSION (le). Matches
-    // `parse_cache.rs`'s header layout -- incorporating the parser schema version invalidates
-    // this cache when the AST schema changes between parser releases, even within a single
-    // spec42 version. Without this, a parser-only dependency bump (e.g. sysml-v2-parser fixing a
-    // parse bug) would leave a stale, pre-fix library graph cached on disk until spec42's own
-    // version next changed, since this cache's only other invalidation trigger was
-    // `CARGO_PKG_VERSION`.
+    // First 12 bytes: spec42 semver string; then PARSE_AST_VERSION and the graph-semantics
+    // version (both le u32). The latter invalidates cached graphs after closure/merge behavior
+    // changes even when the in-development Spec42 semver and parser schema stay unchanged.
     let v = env!("CARGO_PKG_VERSION").as_bytes();
     let mut field = [0u8; VERSION_FIELD_LEN];
     let len = v.len().min(12);
     field[..len].copy_from_slice(&v[..len]);
     field[12..16].copy_from_slice(&sysml_v2_parser::PARSE_AST_VERSION.to_le_bytes());
+    field[16..20].copy_from_slice(&LIBRARY_GRAPH_SEMANTICS_VERSION.to_le_bytes());
     field
 }
 
@@ -233,12 +233,13 @@ pub fn evict_stale_entries() {
 // ---------------------------------------------------------------------------
 
 /// Level-1 cache key: SHA-256 of sorted library paths, workspace closure seeds, binary
-/// version, and parser AST schema version (so a parser-only dependency bump gets a fresh
-/// filename too, not just a header mismatch on an existing one -- see `version_field`).
+/// version, parser AST schema version, and graph-semantics version (so either kind of semantic
+/// change gets a fresh filename too, not just a header mismatch -- see `version_field`).
 fn cache_key(library_paths: &[Url], closure_seed_signature: &[String]) -> [u8; 32] {
     let mut hasher = Sha256::new();
     hasher.update(env!("CARGO_PKG_VERSION").as_bytes());
     hasher.update(sysml_v2_parser::PARSE_AST_VERSION.to_le_bytes());
+    hasher.update(LIBRARY_GRAPH_SEMANTICS_VERSION.to_le_bytes());
     let mut sorted: Vec<&str> = library_paths.iter().map(|u| u.as_str()).collect();
     sorted.sort_unstable();
     for path in sorted {


### PR DESCRIPTION
## Summary

- merge managed domain and method library package fragments into shared namespaces without project-specific configuration
- treat a typed `ref part` as a structural component usage while preserving referential ownership semantics
- project inherited reference-part ports and their connectors into prepared interconnection views and SVG output
- keep the global `is_part_like` predicate, public DTOs, LSP methods, and SysML project models unchanged

## Regression coverage

- component expansion includes typed reference parts and inherited ports
- component expansion excludes untyped reference parts
- end-to-end LSP `InterconnectionView` contains both endpoint ports and exactly one prepared edge
- optical-transceiver validation produces seven transceiver ports, seven prepared edges, and seven SVG `ibd-connector` paths

## Validation

- `cargo test -p sysml_model --lib` — 253 passed, 3 ignored
- focused LSP interconnection integration test — passed
- `cargo check --workspace` — passed
- optical-transceiver workspace check — 0 diagnostics

Closes #6