### PR TITLE
Prefer scoped instance mappings in IBD views

### DIFF
--- a/crates/sysml_model/src/semantic/ibd/instance_paths.rs
+++ b/crates/sysml_model/src/semantic/ibd/instance_paths.rs
@@ -14,8 +14,39 @@ pub(crate) fn infer_def_instance_scope_mappings_for_ibd(ibd: &IbdDataDto) -> Vec
         .iter()
         .map(|mapping| (mapping.def_root.clone(), mapping.instance_root.clone()))
         .collect();
-    mappings.sort_by_key(|mapping| std::cmp::Reverse(mapping.0.len()));
+    mappings.sort_by(|left, right| {
+        right
+            .0
+            .len()
+            .cmp(&left.0.len())
+            .then_with(|| {
+                mapping_scope_relevance(ibd, &right.1).cmp(&mapping_scope_relevance(ibd, &left.1))
+            })
+            .then_with(|| left.1.cmp(&right.1))
+    });
     mappings
+}
+
+fn mapping_scope_relevance(ibd: &IbdDataDto, instance_root: &str) -> u8 {
+    let matches_instance =
+        |value: &str| value == instance_root || value.starts_with(&format!("{instance_root}."));
+    if ibd.connectors.iter().any(|connector| {
+        matches_instance(&connector.source_id) || matches_instance(&connector.target_id)
+    }) {
+        return 2;
+    }
+    if ibd
+        .parts
+        .iter()
+        .any(|part| matches_instance(&part.qualified_name))
+        || ibd
+            .ports
+            .iter()
+            .any(|port| matches_instance(&port.parent_id) || matches_instance(&port.port_id))
+    {
+        return 1;
+    }
+    0
 }
 
 fn remap_qualified_name_with_mappings(value: &str, mappings: &[(String, String)]) -> String {
@@ -74,4 +105,78 @@ pub fn normalize_ibd_to_instance_paths(ibd: &mut IbdDataDto) {
     }
 
     enrich_connector_endpoint_refs(&mut ibd.connectors, &ibd.parts, &ibd.ports);
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::normalize_ibd_to_instance_paths;
+    use crate::semantic::ibd::{
+        DefInstanceMappingDto, IbdConnectorDto, IbdDataDto, IbdPartDto, IbdPortDto,
+    };
+
+    #[test]
+    fn normalization_prefers_instance_mapping_present_in_scoped_connectors() {
+        let definition_root = "Architecture.TransmitterFirstOpticalTransceiver";
+        let definition_part = format!("{definition_root}.transmitter");
+        let architecture_root = "Architecture.transceiverSystem";
+        let architecture_part = format!("{architecture_root}.transmitter");
+        let context_root = "Context.operationalContext.transceiver";
+        let mut ibd = IbdDataDto {
+            parts: vec![IbdPartDto {
+                id: definition_part.replace('.', "::"),
+                node_id: definition_part.clone(),
+                name: "transmitter".to_string(),
+                qualified_name: definition_part.clone(),
+                uri: None,
+                container_id: Some(definition_root.to_string()),
+                element_type: "part".to_string(),
+                attributes: HashMap::new(),
+                range: None,
+            }],
+            ports: vec![IbdPortDto {
+                id: format!("{definition_part}.output").replace('.', "::"),
+                port_id: format!("{definition_part}.output"),
+                name: "output".to_string(),
+                parent_id: definition_part.clone(),
+                direction: None,
+                port_type: None,
+                port_side: None,
+                uri: None,
+                range: None,
+            }],
+            connectors: vec![IbdConnectorDto {
+                source: format!("{architecture_part}.driver.output"),
+                target: format!("{architecture_part}.modulator.input"),
+                source_id: format!("{architecture_part}.driver.output"),
+                target_id: format!("{architecture_part}.modulator.input"),
+                source_part_id: None,
+                target_part_id: None,
+                source_port_id: None,
+                target_port_id: None,
+                rel_type: "connection".to_string(),
+            }],
+            container_groups: Vec::new(),
+            package_container_groups: Vec::new(),
+            root_candidates: Vec::new(),
+            root_views: HashMap::new(),
+            default_root: None,
+            def_instance_mappings: vec![
+                DefInstanceMappingDto {
+                    def_root: definition_root.to_string(),
+                    instance_root: context_root.to_string(),
+                },
+                DefInstanceMappingDto {
+                    def_root: definition_root.to_string(),
+                    instance_root: architecture_root.to_string(),
+                },
+            ],
+        };
+
+        normalize_ibd_to_instance_paths(&mut ibd);
+
+        assert_eq!(ibd.parts[0].qualified_name, architecture_part);
+        assert_eq!(ibd.ports[0].parent_id, architecture_part);
+    }
 }


### PR DESCRIPTION
## Summary

- rank duplicate definition-to-instance mappings by their relevance to the scoped IBD
- prefer instance roots present in connector endpoints, then roots present in scoped parts or ports
- preserve longest-definition-prefix remapping and add deterministic tie-breaking
- add a regression for a context reference and selected architecture occurrence of the same definition

## Validation

- `cargo test -p sysml_model --lib` — 254 passed, 3 ignored
- `cargo check --workspace` — passed
- optical-transceiver `transmitArchitectureView` — selected root `Architecture.transceiverSystem`, 5 prepared nodes, 2 prepared edges

Closes #9