### PR TITLE
Support definition-level binding connectors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2157,9 +2157,9 @@ dependencies = [
 
 [[package]]
 name = "sysml-v2-parser"
-version = "0.51.1"
+version = "0.51.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd95a80d6ce4e56ff35a82ccab7fa9d7db51e4cd26a01a25571333f417dc76f5"
+checksum = "7c9fb64c62ea204fa30e6daf03126039cab3fb56c140a9db1eeaf5fd0c6e6225"
 dependencies = [
  "log",
  "nom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,5 +31,5 @@ clap = { version = "4", features = ["derive"] }
 rmcp = { version = "0.9", features = ["server"] }
 schemars = { version = "1.1", features = ["derive"] }
 petgraph = { version = "0.8", features = ["serde-1"] }
-sysml-v2-parser = {  version = "0.51.1", features = ["serde"] }
+sysml-v2-parser = { version = "0.51.7", features = ["serde"] }
 ts-rs = { version = "11", features = ["serde-compat", "serde-json-impl"] }

--- a/crates/lsp_server/tests/integration/interconnection_visualization.rs
+++ b/crates/lsp_server/tests/integration/interconnection_visualization.rs
@@ -11,16 +11,19 @@ const REF_PART_INTERCONNECTION_MODEL: &str = r#"package RefContext {
 
   part def System {
     port link : LinkPort;
+    port boundLink : LinkPort;
   }
 
   part def Peer {
     port link : LinkPort;
+    port boundLink : LinkPort;
   }
 
   part def Context {
     ref part system : System;
     part peer : Peer;
     connect system.link to peer.link;
+    bind system.boundLink = peer.boundLink;
   }
 
   part context : Context;
@@ -181,7 +184,7 @@ fn lsp_interconnection_visualization_returns_slim_scene_only_payload_for_drone()
 }
 
 #[test]
-fn lsp_interconnection_visualization_projects_connections_to_typed_ref_parts() {
+fn lsp_interconnection_visualization_projects_connections_and_bindings_to_typed_ref_parts() {
     let workspace_dir = tempfile::tempdir().expect("temporary workspace");
     let model_path = workspace_dir.path().join("Model.sysml");
     std::fs::write(&model_path, REF_PART_INTERCONNECTION_MODEL).expect("write model fixture");
@@ -277,6 +280,9 @@ fn lsp_interconnection_visualization_projects_connections_to_typed_ref_parts() {
         .as_array()
         .expect("reference part should expose inherited port details");
     assert!(reference_ports.iter().any(|port| port["name"] == "link"));
+    assert!(reference_ports
+        .iter()
+        .any(|port| port["name"] == "boundLink"));
 
     let peer_part = nodes
         .iter()
@@ -290,11 +296,18 @@ fn lsp_interconnection_visualization_projects_connections_to_typed_ref_parts() {
         .as_array()
         .expect("peer part should expose port details");
     assert!(peer_ports.iter().any(|port| port["name"] == "link"));
+    assert!(peer_ports.iter().any(|port| port["name"] == "boundLink"));
 
     let edges = prepared["edges"]
         .as_array()
         .expect("preparedView.edges should be an array");
-    assert_eq!(edges.len(), 1, "expected exactly one prepared connection");
+    assert_eq!(
+        edges.len(),
+        2,
+        "expected one connection and one binding in the prepared view, got {edges:#?}"
+    );
+    assert!(edges.iter().any(|edge| edge["edgeKind"] == "connection"));
+    assert!(edges.iter().any(|edge| edge["edgeKind"] == "bind"));
     assert!(edges[0]["attributes"]["sourcePortId"].is_string());
     assert!(edges[0]["attributes"]["targetPortId"].is_string());
     assert!(

--- a/crates/server/assets/diagram-renderer/headless-renderer.js
+++ b/crates/server/assets/diagram-renderer/headless-renderer.js
@@ -419,7 +419,8 @@ var Spec42HeadlessRendererBundle = (() => {
       const guard = asString(edge.guard ?? edge.type, "");
       const condition = asString(edge.condition, "");
       const guardLower = guard.toLowerCase();
-      const succession = guardLower === "flow" || guardLower === "first" || guardLower === "succession";
+      const succession = guardLower === "first" || guardLower === "succession" || guardLower === "succession flow";
+      const streamingFlow = guardLower === "flow";
       const conditional = condition.length > 0 || guard.length > 0 && !["flow", "first", "bind", "perform", "succession"].includes(guardLower);
       return {
         id: asString(edge.id, `flow-${index}`),
@@ -430,6 +431,8 @@ var Spec42HeadlessRendererBundle = (() => {
           ...guard ? { guard } : {},
           ...condition ? { condition } : {},
           succession,
+          streamingFlow,
+          flowKind: succession ? "succession" : streamingFlow ? "streaming" : "other",
           conditional
         }
       };
@@ -870,7 +873,22 @@ var Spec42HeadlessRendererBundle = (() => {
       }
     };
   }
+  function rootCoverage(rootId, scene) {
+    const prefix = `${rootId}.`;
+    return scene.nodes.filter((node) => node.id === rootId || node.id.startsWith(prefix)).length;
+  }
+  function selectRoot(scene) {
+    return [...scene.view.rootIds].sort((left, right) => {
+      const coverageDelta = rootCoverage(right, scene) - rootCoverage(left, scene);
+      if (coverageDelta !== 0) return coverageDelta;
+      const depthDelta = left.split(".").length - right.split(".").length;
+      if (depthDelta !== 0) return depthDelta;
+      return left.localeCompare(right);
+    })[0] ?? null;
+  }
   function prepareInterconnectionScene(scene, visualization) {
+    const selectedRoot = selectRoot(scene);
+    const selectedRootHasCoverage = selectedRoot !== null && rootCoverage(selectedRoot, scene) > 0;
     const nodeIds = new Set(scene.nodes.map((node) => node.id));
     const nodes = scene.nodes.map((node) => {
       const nodePorts = portsForNode(node.id, scene.ports);
@@ -896,7 +914,8 @@ var Spec42HeadlessRendererBundle = (() => {
       };
     });
     for (const container of scene.containers) {
-      if (nodeIds.has(container.id)) continue;
+      const inSelectedScope = !selectedRootHasCoverage || selectedRoot === null || container.id === selectedRoot || container.id.startsWith(`${selectedRoot}.`);
+      if (nodeIds.has(container.id) || !inSelectedScope) continue;
       nodes.push({
         id: container.id,
         label: container.label,
@@ -939,7 +958,7 @@ var Spec42HeadlessRendererBundle = (() => {
       meta: {
         canonicalScene: true,
         schemaVersion: scene.schemaVersion,
-        selectedRoot: scene.view.rootIds[0] ?? null,
+        selectedRoot,
         rootCandidates: scene.view.rootIds,
         diagnostics: scene.diagnostics
       }
@@ -982,28 +1001,8 @@ var Spec42HeadlessRendererBundle = (() => {
     const attrs = asRecord(node.attributes);
     return asString(node.id ?? node.qualifiedName ?? attrs.qualifiedName ?? node.name);
   }
-  function traceabilityLinkCount(nodeId, edges) {
-    let links = 0;
-    for (const edge of edges) {
-      const relType = asString(edge.type ?? edge.rel_type).toLowerCase();
-      if (!/(satisfy|derivation|derive|verify|subject)/.test(relType)) continue;
-      const source = asString(edge.source);
-      const target = asString(edge.target);
-      if (source === nodeId || target === nodeId) {
-        links += 1;
-      }
-    }
-    return links;
-  }
-  function packageLabelOf(qualifiedName) {
-    const segments = qualifiedName.split("::").filter(Boolean);
-    return segments.length > 1 ? segments[0] : "";
-  }
   function projectionHints(visualization) {
     return asRecord(visualization?.projectionHints);
-  }
-  function gridLayoutHint(visualization) {
-    return asString(projectionHints(visualization).gridLayout) || void 0;
   }
   function gridSubtypeHint(visualization) {
     return asString(projectionHints(visualization).gridSubtype) || void 0;
@@ -1013,6 +1012,9 @@ var Spec42HeadlessRendererBundle = (() => {
   }
   function treeRootHints(visualization) {
     return asArray(projectionHints(visualization).treeRoots).map((value) => asString(value)).filter(Boolean);
+  }
+  function columnViewsHint(visualization) {
+    return asArray(projectionHints(visualization).columnViews).map(asRecord).map((entry) => ({ label: asString(entry.label, "Column") }));
   }
   function optionalUri(node) {
     return nodeUri(node) ?? void 0;
@@ -1031,9 +1033,6 @@ var Spec42HeadlessRendererBundle = (() => {
       siblings.push(node);
       childrenByParent.set(node.parentId, siblings);
     }
-    for (const siblings of childrenByParent.values()) {
-      siblings.sort((left, right) => left.qualifiedName.localeCompare(right.qualifiedName));
-    }
     const roots = treeRoots.length > 0 ? treeRoots.map((id2) => byId.get(id2)).filter((node) => Boolean(node)) : graphNodes.filter((node) => !node.parentId || !byId.has(node.parentId));
     const rows = [];
     const visit = (node, depth) => {
@@ -1047,7 +1046,6 @@ var Spec42HeadlessRendererBundle = (() => {
         visit(child, depth + 1);
       }
     };
-    roots.sort((left, right) => left.qualifiedName.localeCompare(right.qualifiedName));
     for (const root2 of roots) {
       visit(root2, 0);
     }
@@ -1059,13 +1057,18 @@ var Spec42HeadlessRendererBundle = (() => {
       const source = asString(edge.source);
       const target = asString(edge.target);
       if (!source || !target) continue;
-      edgeByPair.set(`${source}::${target}`, asString(edge.name ?? edge.label ?? edge.type ?? edge.rel_type, ""));
+      const label = asString(edge.name ?? edge.label ?? edge.type ?? edge.rel_type, "");
+      if (!label) continue;
+      const key = `${source}::${target}`;
+      const labels = edgeByPair.get(key) ?? [];
+      labels.push(label);
+      edgeByPair.set(key, labels);
     }
     const cells = [];
     for (const source of nodeIds) {
       for (const target of nodeIds) {
-        const label = edgeByPair.get(`${source}::${target}`) ?? "";
-        cells.push({ source, target, present: label.length > 0, label });
+        const labels = edgeByPair.get(`${source}::${target}`) ?? [];
+        cells.push({ source, target, present: labels.length > 0, labels });
       }
     }
     return cells;
@@ -1077,6 +1080,7 @@ var Spec42HeadlessRendererBundle = (() => {
       kind: elementTypeOf(node) || "element",
       parentId: asString(firstPresent(node.parent_id, node.parentId, asRecord(node.attributes).parentId)),
       qualifiedName: qualifiedNameOf(node),
+      visibility: asString(asRecord(node.attributes).visibility) || void 0,
       uri: optionalUri(node),
       range: optionalRange(node)
     }));
@@ -1099,20 +1103,16 @@ var Spec42HeadlessRendererBundle = (() => {
   }
   function prepareGrid(visualization) {
     const graphEdges = graphEdgesForStandardView(visualization);
-    const traceabilityLayout = gridLayoutHint(visualization) === "traceability";
     const relationshipMatrix = gridSubtypeHint(visualization) === "relationship_matrix";
     const cells = graphNodesForStandardView(visualization).map((node) => {
       const attrs = asRecord(node.attributes);
       const qualifiedName = qualifiedNameOf(node);
       const nodeId = asString(node.id);
-      const linkCount = traceabilityLinkCount(nodeId, graphEdges);
       return {
         id: nodeId,
         name: asString(node.name ?? node.qualifiedName ?? node.id, "Unnamed"),
         kind: elementTypeOf(node) || "element",
-        package: packageLabelOf(qualifiedName),
         qualifiedName,
-        linkCount,
         attributeCount: asArray(attrs.attributes).length,
         partCount: asArray(attrs.parts).length,
         portCount: asArray(attrs.ports).length,
@@ -1122,6 +1122,7 @@ var Spec42HeadlessRendererBundle = (() => {
     }).sort((left, right) => left.qualifiedName.localeCompare(right.qualifiedName));
     const nodeIds = cells.map((cell) => cell.id).filter(Boolean);
     const matrixCells = relationshipMatrix ? buildRelationshipMatrix(nodeIds, graphEdges) : [];
+    const columnViews = columnViewsHint(visualization);
     return {
       title: asString(visualization?.selectedViewName, "Grid View"),
       view: "grid-view",
@@ -1136,11 +1137,11 @@ var Spec42HeadlessRendererBundle = (() => {
       edges: [],
       meta: {
         cells,
-        traceabilityTable: traceabilityLayout,
         relationshipMatrix,
         matrixRowIds: relationshipMatrix ? nodeIds : [],
         matrixColIds: relationshipMatrix ? nodeIds : [],
         matrixCells,
+        columns: columnViews.length > 0 ? columnViews.map((column) => ({ key: "name", label: column.label })) : void 0,
         // Both an element table and a relationship matrix are rectangular GridView
         // presentations described by §9.2.20.2.5.
         provisional: false
@@ -4719,12 +4720,13 @@ var Spec42HeadlessRendererBundle = (() => {
       const fallback = fallbackEdgePath(source, target, horizontal);
       const edgeAttrs = edge.attributes ?? {};
       const guard = String(edgeAttrs.guard ?? edge.label ?? "").toLowerCase();
-      const succession = Boolean(edgeAttrs.succession) || guard === "flow" || guard === "first" || guard === "succession";
+      const succession = Boolean(edgeAttrs.succession) || guard === "first" || guard === "succession" || guard === "succession flow";
+      const streamingFlow = Boolean(edgeAttrs.streamingFlow) || guard === "flow";
       const conditional = Boolean(edgeAttrs.conditional);
       flowLayer.append("path").attr(
         "class",
-        succession ? conditional ? "activity-flow action-flow-edge aflow-succession aflow-conditional" : "activity-flow action-flow-edge aflow-succession" : "activity-flow action-flow-edge"
-      ).attr("d", pathFromSections(sections) || fallback.path).style("fill", "none").style("stroke", ctx.theme.edge.default).style("stroke-width", "2px").style("marker-end", "url(#action-flow-arrow)");
+        succession ? conditional ? "activity-flow action-flow-edge aflow-succession aflow-conditional" : "activity-flow action-flow-edge aflow-succession" : streamingFlow ? "activity-flow action-flow-edge aflow-streaming" : "activity-flow action-flow-edge"
+      ).attr("data-flow-kind", succession ? "succession" : streamingFlow ? "streaming" : "other").attr("d", pathFromSections(sections) || fallback.path).style("fill", "none").style("stroke", ctx.theme.edge.default).style("stroke-width", "2px").style("stroke-dasharray", succession ? "7,4" : "none").style("marker-end", "url(#action-flow-arrow)");
       const label = truncateLabel(edge.label, 20);
       if (label && !["flow", "first", "bind"].includes(label.toLowerCase())) {
         const elkLabel = layout.edgeLabelsById.get(edge.id)?.[0];
@@ -5015,293 +5017,6 @@ var Spec42HeadlessRendererBundle = (() => {
     defs.append("marker").attr("id", "state-transition-arrow").attr("viewBox", "0 -5 10 10").attr("refX", 8).attr("refY", 0).attr("markerWidth", 6).attr("markerHeight", 6).attr("orient", "auto").append("path").attr("d", "M0,-5L10,0L0,5").style("fill", theme.edge.default);
   }
 
-  // ../shared/diagram-renderer/src/views/standard-views-render.ts
-  function drawProvisionalBadge(root2, theme, label = "provisional SysML notation") {
-    const badge = root2.append("g").attr("class", "provisional-view-badge");
-    badge.append("rect").attr("x", 22).attr("y", 42).attr("width", 176).attr("height", 24).attr("rx", 5).style("fill", theme.canvasBackground).style("stroke", theme.edge.default).style("stroke-dasharray", "4,3");
-    badge.append("text").attr("x", 34).attr("y", 58).style("font-size", "10px").style("fill", theme.textSecondary).text(label);
-  }
-  function nodeFromMeta(row, fallback) {
-    const id2 = asString(row.id);
-    return fallback.find((node) => node.id === id2 || node.label === asString(row.label ?? row.name));
-  }
-  function shortMatrixLabel(id2) {
-    const segments = id2.split("::").filter(Boolean);
-    return truncateLabel(segments[segments.length - 1] ?? id2, 10);
-  }
-  function renderBrowserView(ctx) {
-    const rows = asArray(ctx.prepared.meta?.rows).map(asRecord);
-    const sourceRows = rows.length > 0 ? rows : ctx.prepared.nodes.map((node) => ({ id: node.id, label: node.label, kind: node.kind }));
-    const hierarchyLayout = Boolean(ctx.prepared.meta?.hierarchyLayout);
-    const rowHeight = 28;
-    const left = 52;
-    const top = 88;
-    const width = Math.max(520, Math.min(920, ctx.width - 120));
-    const collapsed = /* @__PURE__ */ new Set();
-    ctx.root.append("text").attr("x", 24).attr("y", 28).style("font-size", "14px").style("font-weight", "700").style("fill", ctx.theme.textPrimary).text(ctx.prepared.title || "Browser View");
-    if (!hierarchyLayout) {
-      drawProvisionalBadge(ctx.root, ctx.theme);
-    }
-    const layer = ctx.root.append("g").attr("class", "browser-view-rows");
-    const isRowVisible = (row, index) => {
-      if (!hierarchyLayout) return true;
-      const parentId = asString(row.parentId);
-      if (!parentId) return true;
-      for (let cursor = index - 1; cursor >= 0; cursor -= 1) {
-        const ancestor = asRecord(sourceRows[cursor]);
-        if (asString(ancestor.id) !== parentId) continue;
-        if (!isRowVisible(ancestor, cursor) || collapsed.has(parentId)) {
-          return false;
-        }
-        return true;
-      }
-      return !collapsed.has(parentId);
-    };
-    const redraw = () => {
-      layer.selectAll("*").remove();
-      let visibleIndex = 0;
-      sourceRows.forEach((row, index) => {
-        if (!isRowVisible(row, index)) return;
-        const y2 = top + visibleIndex * rowHeight;
-        visibleIndex += 1;
-        const depth = hierarchyLayout ? Number(row.depth ?? 0) : Math.max(0, asString(row.qualifiedName).split("::").filter(Boolean).length - 1);
-        const hasChildren = Boolean(row.hasChildren);
-        const preparedNode = nodeFromMeta(row, ctx.prepared.nodes);
-        const rowId = preparedNode?.id ?? asString(row.id, `browser-row-${index}`);
-        const item = layer.append("g").attr("class", "browser-row").attr("data-node-id", rowId).attr("transform", `translate(${left},${y2})`);
-        item.append("rect").attr("class", "node-background").attr("data-original-stroke", ctx.theme.nodeBorder).attr("data-original-width", "1px").attr("width", width).attr("height", rowHeight - 3).attr("rx", 4).style("fill", visibleIndex % 2 === 0 ? ctx.theme.nodeFill : ctx.theme.canvasBackground).style("stroke", ctx.theme.nodeBorder).style("stroke-width", "1px").style("opacity", 0.9);
-        if (hasChildren) {
-          const toggle = item.append("text").attr("x", 8 + depth * 16).attr("y", 18).attr("class", "browser-toggle").style("font-size", "11px").style("font-weight", "700").style("fill", ctx.theme.textSecondary).style("cursor", "pointer").text(collapsed.has(rowId) ? "\u25B8" : "\u25BE");
-          toggle.on("click", (event) => {
-            event.stopPropagation();
-            if (collapsed.has(rowId)) {
-              collapsed.delete(rowId);
-            } else {
-              collapsed.add(rowId);
-            }
-            redraw();
-          });
-        }
-        item.append("text").attr("x", 14 + depth * 16 + (hasChildren ? 12 : 0)).attr("y", 18).style("font-size", "11px").style("font-weight", "600").style("fill", ctx.theme.textPrimary).text(truncateLabel(asString(row.label ?? row.name ?? row.id, "Unnamed"), 48));
-        item.append("text").attr("x", width - 14).attr("y", 18).attr("text-anchor", "end").style("font-size", "10px").style("fill", ctx.theme.textSecondary).text(truncateLabel(asString(row.kind, "element"), 24));
-        if (preparedNode) {
-          attachBehaviorNodeClick(item, preparedNode, ctx.theme, ctx.options ?? {}, ctx.root);
-        }
-      });
-    };
-    redraw();
-    const visibleCount = hierarchyLayout ? sourceRows.filter((row, index) => isRowVisible(row, index)).length : sourceRows.length;
-    return { minX: 0, minY: 0, maxX: left + width + 80, maxY: top + visibleCount * rowHeight + 80 };
-  }
-  function renderGridView(ctx) {
-    const relationshipMatrix = Boolean(ctx.prepared.meta?.relationshipMatrix);
-    if (relationshipMatrix) {
-      return renderRelationshipMatrix(ctx);
-    }
-    const cells = asArray(ctx.prepared.meta?.cells).map(asRecord);
-    const rows = cells.length > 0 ? cells : ctx.prepared.nodes.map((node) => asRecord(node.attributes));
-    const left = 52;
-    const top = 92;
-    const traceabilityTable = Boolean(ctx.prepared.meta?.traceabilityTable);
-    const columns = traceabilityTable ? [
-      { key: "name", label: "Name", width: 240 },
-      { key: "kind", label: "Kind", width: 130 },
-      { key: "package", label: "Package", width: 170 },
-      { key: "linkCount", label: "Links", width: 70 }
-    ] : [
-      { key: "name", label: "Name", width: 220 },
-      { key: "kind", label: "Kind", width: 150 },
-      { key: "attributeCount", label: "Attrs", width: 80 },
-      { key: "partCount", label: "Parts", width: 80 },
-      { key: "portCount", label: "Ports", width: 80 }
-    ];
-    const tableWidth = columns.reduce((sum, column) => sum + column.width, 0);
-    const rowHeight = 30;
-    ctx.root.append("text").attr("x", 24).attr("y", 28).style("font-size", "14px").style("font-weight", "700").style("fill", ctx.theme.textPrimary).text(ctx.prepared.title || "Grid View");
-    if (Boolean(ctx.prepared.meta?.provisional)) {
-      drawProvisionalBadge(ctx.root, ctx.theme);
-    }
-    const table = ctx.root.append("g").attr("class", "grid-view-table").attr("transform", `translate(${left},${top})`);
-    let x2 = 0;
-    columns.forEach((column) => {
-      table.append("rect").attr("class", "grid-header-cell").attr("x", x2).attr("width", column.width).attr("height", rowHeight).style("fill", ctx.theme.nodeBorder).style("stroke", ctx.theme.nodeBorder);
-      table.append("text").attr("x", x2 + 10).attr("y", 20).style("font-size", "11px").style("font-weight", "700").style("fill", ctx.theme.canvasBackground).text(column.label);
-      x2 += column.width;
-    });
-    rows.forEach((row, rowIndex) => {
-      x2 = 0;
-      const preparedNode = nodeFromMeta(row, ctx.prepared.nodes);
-      const group = table.append("g").attr("class", "grid-row").attr("data-node-id", preparedNode?.id ?? asString(row.id, `grid-row-${rowIndex}`)).attr("transform", `translate(0,${(rowIndex + 1) * rowHeight})`);
-      columns.forEach((column) => {
-        group.append("rect").attr("class", "grid-cell").attr("x", x2).attr("width", column.width).attr("height", rowHeight).style("fill", rowIndex % 2 === 0 ? ctx.theme.nodeFill : ctx.theme.canvasBackground).style("stroke", ctx.theme.nodeBorder).style("stroke-width", "1px");
-        group.append("text").attr("x", x2 + 10).attr("y", 20).style("font-size", "10px").style("fill", ctx.theme.textPrimary).text(truncateLabel(asString(row[column.key]), column.width > 100 ? 28 : 8));
-        x2 += column.width;
-      });
-      if (preparedNode) {
-        attachBehaviorNodeClick(group, preparedNode, ctx.theme, ctx.options ?? {}, ctx.root);
-      }
-    });
-    return { minX: 0, minY: 0, maxX: left + tableWidth + 80, maxY: top + (rows.length + 2) * rowHeight + 80 };
-  }
-  function renderRelationshipMatrix(ctx) {
-    const rowIds = asArray(ctx.prepared.meta?.matrixRowIds).map((value) => asString(value)).filter(Boolean);
-    const colIds = asArray(ctx.prepared.meta?.matrixColIds).map((value) => asString(value)).filter(Boolean);
-    const matrixCells = asArray(ctx.prepared.meta?.matrixCells).map(asRecord);
-    const cellSize = 34;
-    const headerSize = 120;
-    const left = 180;
-    const top = 92;
-    ctx.root.append("text").attr("x", 24).attr("y", 28).style("font-size", "14px").style("font-weight", "700").style("fill", ctx.theme.textPrimary).text(ctx.prepared.title || "Relationship Matrix");
-    const layer = ctx.root.append("g").attr("class", "grid-relationship-matrix").attr("transform", `translate(${left},${top})`);
-    colIds.forEach((colId, colIndex) => {
-      layer.append("text").attr("x", headerSize + colIndex * cellSize + cellSize / 2).attr("y", 16).attr("text-anchor", "middle").attr("transform", `rotate(-35, ${headerSize + colIndex * cellSize + cellSize / 2}, 16)`).style("font-size", "9px").style("fill", ctx.theme.textSecondary).text(shortMatrixLabel(colId));
-    });
-    rowIds.forEach((rowId, rowIndex) => {
-      layer.append("text").attr("x", headerSize - 8).attr("y", headerSize + rowIndex * cellSize + cellSize / 2 + 4).attr("text-anchor", "end").style("font-size", "10px").style("fill", ctx.theme.textPrimary).text(shortMatrixLabel(rowId));
-      colIds.forEach((colId, colIndex) => {
-        const cell = matrixCells.find(
-          (entry) => asString(entry.source) === rowId && asString(entry.target) === colId
-        );
-        const present = Boolean(cell?.present);
-        const x2 = headerSize + colIndex * cellSize;
-        const y2 = headerSize + rowIndex * cellSize;
-        layer.append("rect").attr("x", x2).attr("y", y2).attr("width", cellSize - 2).attr("height", cellSize - 2).style("fill", present ? ctx.theme.nodeFill : ctx.theme.canvasBackground).style("stroke", ctx.theme.nodeBorder).style("stroke-width", "1px");
-        if (present) {
-          layer.append("text").attr("x", x2 + (cellSize - 2) / 2).attr("y", y2 + (cellSize - 2) / 2 + 4).attr("text-anchor", "middle").style("font-size", "12px").style("font-weight", "700").style("fill", ctx.theme.edge.default).text("\u25CF");
-        }
-      });
-    });
-    const width = headerSize + colIds.length * cellSize + 40;
-    const height = headerSize + rowIds.length * cellSize + 40;
-    return { minX: 0, minY: 0, maxX: left + width, maxY: top + height };
-  }
-  function renderGeometryView(ctx) {
-    const elements = asArray(ctx.prepared.meta?.elements).map(asRecord);
-    const nodes = elements.length > 0 ? elements : ctx.prepared.nodes.map((node) => ({ id: node.id, label: node.label, kind: node.kind }));
-    const geometryMode = asString(ctx.prepared.meta?.geometryMode, "2d");
-    const geometryProjection = asString(ctx.prepared.meta?.geometryProjection, "orthographic");
-    const left = 64;
-    const top = 88;
-    const cellWidth = 128;
-    const cellHeight = 72;
-    const columns = Math.max(1, Math.ceil(Math.sqrt(nodes.length)));
-    ctx.root.append("text").attr("x", 24).attr("y", 28).style("font-size", "14px").style("font-weight", "700").style("fill", ctx.theme.textPrimary).text(ctx.prepared.title || "Geometry View");
-    if (Boolean(ctx.prepared.meta?.provisional)) {
-      drawProvisionalBadge(ctx.root, ctx.theme, `${geometryMode} ${geometryProjection} preview`);
-    }
-    const layer = ctx.root.append("g").attr("class", "geometry-view-scene").attr("transform", `translate(${left},${top})`);
-    layer.append("rect").attr("width", columns * cellWidth + 24).attr("height", Math.ceil(nodes.length / columns) * cellHeight + 24).attr("rx", 8).style("fill", "none").style("stroke", ctx.theme.frame.stroke).style("stroke-dasharray", "8,6");
-    nodes.forEach((node, index) => {
-      const col = index % columns;
-      const row = Math.floor(index / columns);
-      const x2 = col * cellWidth + 12;
-      const y2 = row * cellHeight + 12;
-      const preparedNode = nodeFromMeta(node, ctx.prepared.nodes);
-      const item = layer.append("g").attr("class", "geometry-object").attr("data-node-id", preparedNode?.id ?? asString(node.id, `geometry-node-${index}`)).attr("transform", `translate(${x2},${y2})`);
-      item.append("rect").attr("class", "node-background").attr("data-original-stroke", ctx.theme.nodeBorder).attr("data-original-width", "1.5px").attr("width", cellWidth - 20).attr("height", cellHeight - 16).attr("rx", 6).style("fill", ctx.theme.nodeFill).style("stroke", ctx.theme.nodeBorder).style("stroke-width", "1.5px");
-      item.append("text").attr("x", (cellWidth - 20) / 2).attr("y", 24).attr("text-anchor", "middle").style("font-size", "10px").style("font-weight", "700").style("fill", ctx.theme.textPrimary).text(truncateLabel(asString(node.label ?? node.name ?? node.id), 16));
-      item.append("text").attr("x", (cellWidth - 20) / 2).attr("y", 42).attr("text-anchor", "middle").style("font-size", "8px").style("fill", ctx.theme.textSecondary).text(truncateLabel(asString(node.kind, "element"), 18));
-      if (preparedNode) {
-        attachBehaviorNodeClick(item, preparedNode, ctx.theme, ctx.options ?? {}, ctx.root);
-      }
-    });
-    const width = columns * cellWidth + 80;
-    const height = Math.ceil(nodes.length / columns) * cellHeight + 120;
-    return { minX: 0, minY: 0, maxX: left + width, maxY: top + height };
-  }
-
-  // ../shared/diagram-renderer/src/render/types.ts
-  var nodeWidth = 200;
-  var nodeHeight = 70;
-  var ibdNodeWidth = 280;
-  var ibdNodeHeight = 140;
-  function contentBoundsFromExtents(extents) {
-    const width = extents.maxX - extents.minX;
-    const height = extents.maxY - extents.minY;
-    return {
-      x: extents.minX,
-      y: extents.minY,
-      width: width > 0 ? width : 1,
-      height: height > 0 ? height : 1
-    };
-  }
-  function compareIbdPorts(node, a, b, usageForPort) {
-    const usageA = usageForPort(node, a);
-    const usageB = usageForPort(node, b);
-    const degreeA = usageA.sourceCount + usageA.targetCount;
-    const degreeB = usageB.sourceCount + usageB.targetCount;
-    if (degreeB !== degreeA) return degreeB - degreeA;
-    return a.name.localeCompare(b.name);
-  }
-  function splitIbdPortsBySide(node, ports, sideForPort, usageForPort) {
-    const west = [];
-    const east = [];
-    for (const port of ports) {
-      (sideForPort(port, node) === "WEST" ? west : east).push(port);
-    }
-    const compare = (a, b) => compareIbdPorts(node, a, b, usageForPort);
-    west.sort(compare);
-    east.sort(compare);
-    return { west, east };
-  }
-  function computeIbdLeafHeight(node, ports, portRows) {
-    const attrs = node.attributes ?? {};
-    const headerHeight = attrs.partType ? 50 : 38;
-    const children2 = Array.isArray(attrs.children) ? attrs.children : [];
-    const contentLineCount = children2.filter(
-      (child) => child && typeof child === "object" && String(child.name || "")
-    ).length;
-    const contentHeight = Math.min(contentLineCount, 8) * 12 + 10;
-    const portSpacing = 26;
-    const portsHeight = ports.length > 0 ? portRows * portSpacing + 22 : 0;
-    return Math.min(340, Math.max(ibdNodeHeight, headerHeight + contentHeight + portsHeight));
-  }
-
-  // ../shared/diagram-renderer/src/render/export.ts
-  function contentBounds(layout) {
-    if (!layout.nodes.length) return { x: 0, y: 0, width: 100, height: 100 };
-    const minX = Math.min(...layout.nodes.map((node) => node.x || 0));
-    const minY = Math.min(...layout.nodes.map((node) => node.y || 0));
-    const maxX = Math.max(...layout.nodes.map((node) => (node.x || 0) + (node.width || nodeWidth)));
-    const maxY = Math.max(...layout.nodes.map((node) => (node.y || 0) + (node.height || nodeHeight)));
-    return { x: minX, y: minY, width: maxX - minX, height: maxY - minY };
-  }
-  function applyFit(svg, zoom, root2, bounds, width, height, isInterconnectionView = false, delegateZoom = false) {
-    const padding = 48;
-    const minScale = isInterconnectionView ? 0.2 : 0.08;
-    const maxScale = isInterconnectionView ? 1.1 : 1.3;
-    const scale = Math.min(
-      maxScale,
-      Math.max(minScale, Math.min((width - padding * 2) / bounds.width, (height - padding * 2) / bounds.height))
-    );
-    const tx = (width - bounds.width * scale) / 2 - bounds.x * scale;
-    const ty = (height - bounds.height * scale) / 2 - bounds.y * scale;
-    const transform2 = identity2.translate(tx, ty).scale(scale);
-    if (delegateZoom) {
-      root2.attr("transform", transform2.toString());
-      return transform2;
-    }
-    svg.transition().duration(180).call(zoom.transform, transform2);
-    return transform2;
-  }
-  function addMarkers(svg, theme) {
-    const defs = svg.append("defs");
-    defs.append("marker").attr("id", "viz-arrow").attr("markerWidth", 10).attr("markerHeight", 10).attr("refX", 9).attr("refY", 3).attr("orient", "auto").attr("markerUnits", "strokeWidth").append("path").attr("d", "M0,0 L0,6 L9,3 z").attr("fill", theme.edge.default);
-    defs.append("marker").attr("id", "general-d3-arrow").attr("viewBox", "0 -5 10 10").attr("refX", 8).attr("refY", 0).attr("markerWidth", 5).attr("markerHeight", 5).attr("orient", "auto").append("path").attr("d", "M0,-4L10,0L0,4").style("fill", theme.edge.default);
-    defs.append("marker").attr("id", "general-d3-arrow-open").attr("viewBox", "0 -5 10 10").attr("refX", 9).attr("refY", 0).attr("markerWidth", 8).attr("markerHeight", 8).attr("orient", "auto").append("path").attr("d", "M0,-4L10,0L0,4").style("fill", "none").style("stroke", theme.edge.default).style("stroke-width", "1.3");
-    defs.append("marker").attr("id", "general-d3-specializes").attr("viewBox", "0 -6 12 12").attr("refX", 11).attr("refY", 0).attr("markerWidth", 8).attr("markerHeight", 8).attr("orient", "auto").append("path").attr("d", "M0,0L10,-4L10,4Z").style("fill", theme.nodeFill).style("stroke", theme.edge.default).style("stroke-width", "1.2");
-    defs.append("marker").attr("id", "general-d3-diamond").attr("viewBox", "0 -6 12 12").attr("refX", 2).attr("refY", 0).attr("markerWidth", 7).attr("markerHeight", 7).attr("orient", "auto").append("path").attr("d", "M0,0L5,-4L10,0L5,4Z").style("fill", theme.edge.default);
-    defs.append("marker").attr("id", "ibd-connection-dot").attr("viewBox", "-5 -5 10 10").attr("refX", 0).attr("refY", 0).attr("markerWidth", 5).attr("markerHeight", 5).attr("orient", "auto").append("circle").attr("r", 3).style("fill", theme.nodeFill).style("stroke", theme.edge.default).style("stroke-width", "1.5");
-    defs.append("marker").attr("id", "ibd-flow-arrow").attr("viewBox", "0 -5 10 10").attr("refX", 10).attr("refY", 0).attr("markerWidth", 8).attr("markerHeight", 8).attr("orient", "auto").append("path").attr("d", "M0,-4L10,0L0,4Z").style("fill", theme.edge.default);
-    defs.append("marker").attr("id", "ibd-interface-arrow").attr("viewBox", "0 -5 10 10").attr("refX", 10).attr("refY", 0).attr("markerWidth", 8).attr("markerHeight", 8).attr("orient", "auto").append("path").attr("d", "M0,-4L10,0L0,4Z").style("fill", "none").style("stroke", theme.edge.default).style("stroke-width", "1.5");
-  }
-  function exportSvg(svgNode2, bounds) {
-    const clone = svgNode2.cloneNode(true);
-    clone.setAttribute("xmlns", "http://www.w3.org/2000/svg");
-    clone.setAttribute("viewBox", `${bounds.x - 40} ${bounds.y - 40} ${bounds.width + 80} ${bounds.height + 80}`);
-    return new XMLSerializer().serializeToString(clone);
-  }
-
   // ../shared/diagram-renderer/src/sysml-node-builder.ts
   var LINE_HEIGHT = 12;
   var COMPARTMENT_LABEL_HEIGHT = 14;
@@ -5521,6 +5236,315 @@ var Spec42HeadlessRendererBundle = (() => {
       renderCompartment(section.title, section.items, Boolean(section.collapsed));
     }
     return node;
+  }
+
+  // ../shared/diagram-renderer/src/views/standard-views-render.ts
+  function visibilityGlyph(visibility) {
+    switch (visibility) {
+      case "Public":
+        return "+ ";
+      case "Private":
+        return "- ";
+      case "Protected":
+        return "# ";
+      default:
+        return "";
+    }
+  }
+  function drawProvisionalBadge(root2, theme, label = "provisional SysML notation") {
+    const badge = root2.append("g").attr("class", "provisional-view-badge");
+    badge.append("rect").attr("x", 22).attr("y", 42).attr("width", 176).attr("height", 24).attr("rx", 5).style("fill", theme.canvasBackground).style("stroke", theme.edge.default).style("stroke-dasharray", "4,3");
+    badge.append("text").attr("x", 34).attr("y", 58).style("font-size", "10px").style("fill", theme.textSecondary).text(label);
+  }
+  function nodeFromMeta(row, fallback) {
+    const id2 = asString(row.id);
+    return fallback.find((node) => node.id === id2 || node.label === asString(row.label ?? row.name));
+  }
+  function shortMatrixLabel(id2) {
+    const segments = id2.split("::").filter(Boolean);
+    return truncateLabel(segments[segments.length - 1] ?? id2, 10);
+  }
+  function renderBrowserView(ctx) {
+    const rows = asArray(ctx.prepared.meta?.rows).map(asRecord);
+    const sourceRows = rows.length > 0 ? rows : ctx.prepared.nodes.map((node) => ({ id: node.id, label: node.label, kind: node.kind }));
+    const hierarchyLayout = Boolean(ctx.prepared.meta?.hierarchyLayout);
+    const rowHeight = 28;
+    const left = 52;
+    const top = 88;
+    const width = Math.max(520, Math.min(920, ctx.width - 120));
+    const collapsed = /* @__PURE__ */ new Set();
+    ctx.root.append("text").attr("x", 24).attr("y", 28).style("font-size", "14px").style("font-weight", "700").style("fill", ctx.theme.textPrimary).text(ctx.prepared.title || "Browser View");
+    if (!hierarchyLayout) {
+      drawProvisionalBadge(ctx.root, ctx.theme);
+    }
+    const layer = ctx.root.append("g").attr("class", "browser-view-rows");
+    const isRowVisible = (row, index) => {
+      if (!hierarchyLayout) return true;
+      const parentId = asString(row.parentId);
+      if (!parentId) return true;
+      for (let cursor = index - 1; cursor >= 0; cursor -= 1) {
+        const ancestor = asRecord(sourceRows[cursor]);
+        if (asString(ancestor.id) !== parentId) continue;
+        if (!isRowVisible(ancestor, cursor) || collapsed.has(parentId)) {
+          return false;
+        }
+        return true;
+      }
+      return !collapsed.has(parentId);
+    };
+    const redraw = () => {
+      layer.selectAll("*").remove();
+      let visibleIndex = 0;
+      sourceRows.forEach((row, index) => {
+        if (!isRowVisible(row, index)) return;
+        const y2 = top + visibleIndex * rowHeight;
+        visibleIndex += 1;
+        const depth = hierarchyLayout ? Number(row.depth ?? 0) : Math.max(0, asString(row.qualifiedName).split("::").filter(Boolean).length - 1);
+        const hasChildren = Boolean(row.hasChildren);
+        const preparedNode = nodeFromMeta(row, ctx.prepared.nodes);
+        const rowId = preparedNode?.id ?? asString(row.id, `browser-row-${index}`);
+        const item = layer.append("g").attr("class", "browser-row").attr("data-node-id", rowId).attr("transform", `translate(${left},${y2})`);
+        item.append("rect").attr("class", "node-background").attr("data-original-stroke", ctx.theme.nodeBorder).attr("data-original-width", "1px").attr("width", width).attr("height", rowHeight - 3).attr("rx", 4).style("fill", visibleIndex % 2 === 0 ? ctx.theme.nodeFill : ctx.theme.canvasBackground).style("stroke", ctx.theme.nodeBorder).style("stroke-width", "1px").style("opacity", 0.9);
+        if (hasChildren) {
+          const toggle = item.append("text").attr("x", 8 + depth * 16).attr("y", 18).attr("class", "browser-toggle").style("font-size", "11px").style("font-weight", "700").style("fill", ctx.theme.textSecondary).style("cursor", "pointer").text(collapsed.has(rowId) ? "\u25B8" : "\u25BE");
+          toggle.on("click", (event) => {
+            event.stopPropagation();
+            if (collapsed.has(rowId)) {
+              collapsed.delete(rowId);
+            } else {
+              collapsed.add(rowId);
+            }
+            redraw();
+          });
+        }
+        const visibilityPrefix = visibilityGlyph(asString(row.visibility));
+        item.append("text").attr("x", 14 + depth * 16 + (hasChildren ? 12 : 0)).attr("y", 18).style("font-size", "11px").style("font-weight", "600").style("fill", ctx.theme.textPrimary).text(
+          `${visibilityPrefix}${truncateLabel(asString(row.label ?? row.name ?? row.id, "Unnamed"), 48)}`
+        );
+        item.append("text").attr("x", width - 14).attr("y", 18).attr("text-anchor", "end").style("font-size", "10px").style("fill", ctx.theme.textSecondary).text(formatStereotype(truncateLabel(asString(row.kind, "element"), 24)));
+        if (preparedNode) {
+          attachBehaviorNodeClick(item, preparedNode, ctx.theme, ctx.options ?? {}, ctx.root);
+        }
+      });
+    };
+    redraw();
+    const visibleCount = hierarchyLayout ? sourceRows.filter((row, index) => isRowVisible(row, index)).length : sourceRows.length;
+    return { minX: 0, minY: 0, maxX: left + width + 80, maxY: top + visibleCount * rowHeight + 80 };
+  }
+  function renderGridView(ctx) {
+    const relationshipMatrix = Boolean(ctx.prepared.meta?.relationshipMatrix);
+    if (relationshipMatrix) {
+      return renderRelationshipMatrix(ctx);
+    }
+    const cells = asArray(ctx.prepared.meta?.cells).map(asRecord);
+    const rows = cells.length > 0 ? cells : ctx.prepared.nodes.map((node) => asRecord(node.attributes));
+    const left = 52;
+    const top = 92;
+    const columnViews = asArray(ctx.prepared.meta?.columns).map(asRecord);
+    const columns = columnViews.length > 0 ? columnViews.map((column) => ({
+      key: asString(column.key, "name"),
+      label: asString(column.label, "Column"),
+      width: 220
+    })) : [
+      { key: "name", label: "Name", width: 220 },
+      { key: "kind", label: "Kind", width: 150 },
+      { key: "attributeCount", label: "Attrs", width: 80 },
+      { key: "partCount", label: "Parts", width: 80 },
+      { key: "portCount", label: "Ports", width: 80 }
+    ];
+    const tableWidth = columns.reduce((sum, column) => sum + column.width, 0);
+    const rowHeight = 30;
+    ctx.root.append("text").attr("x", 24).attr("y", 28).style("font-size", "14px").style("font-weight", "700").style("fill", ctx.theme.textPrimary).text(ctx.prepared.title || "Grid View");
+    if (Boolean(ctx.prepared.meta?.provisional)) {
+      drawProvisionalBadge(ctx.root, ctx.theme);
+    }
+    const table = ctx.root.append("g").attr("class", "grid-view-table").attr("transform", `translate(${left},${top})`);
+    let x2 = 0;
+    columns.forEach((column) => {
+      table.append("rect").attr("class", "grid-header-cell").attr("x", x2).attr("width", column.width).attr("height", rowHeight).style("fill", ctx.theme.nodeBorder).style("stroke", ctx.theme.nodeBorder);
+      table.append("text").attr("x", x2 + 10).attr("y", 20).style("font-size", "11px").style("font-weight", "700").style("fill", ctx.theme.canvasBackground).text(column.label);
+      x2 += column.width;
+    });
+    rows.forEach((row, rowIndex) => {
+      x2 = 0;
+      const preparedNode = nodeFromMeta(row, ctx.prepared.nodes);
+      const group = table.append("g").attr("class", "grid-row").attr("data-node-id", preparedNode?.id ?? asString(row.id, `grid-row-${rowIndex}`)).attr("transform", `translate(0,${(rowIndex + 1) * rowHeight})`);
+      columns.forEach((column) => {
+        group.append("rect").attr("class", "grid-cell").attr("x", x2).attr("width", column.width).attr("height", rowHeight).style("fill", rowIndex % 2 === 0 ? ctx.theme.nodeFill : ctx.theme.canvasBackground).style("stroke", ctx.theme.nodeBorder).style("stroke-width", "1px");
+        group.append("text").attr("x", x2 + 10).attr("y", 20).style("font-size", "10px").style("fill", ctx.theme.textPrimary).text(truncateLabel(asString(row[column.key]), column.width > 100 ? 28 : 8));
+        x2 += column.width;
+      });
+      if (preparedNode) {
+        attachBehaviorNodeClick(group, preparedNode, ctx.theme, ctx.options ?? {}, ctx.root);
+      }
+    });
+    return { minX: 0, minY: 0, maxX: left + tableWidth + 80, maxY: top + (rows.length + 2) * rowHeight + 80 };
+  }
+  function renderRelationshipMatrix(ctx) {
+    const rowIds = asArray(ctx.prepared.meta?.matrixRowIds).map((value) => asString(value)).filter(Boolean);
+    const colIds = asArray(ctx.prepared.meta?.matrixColIds).map((value) => asString(value)).filter(Boolean);
+    const matrixCells = asArray(ctx.prepared.meta?.matrixCells).map(asRecord);
+    const cellSize = 34;
+    const headerSize = 120;
+    const left = 180;
+    const top = 92;
+    ctx.root.append("text").attr("x", 24).attr("y", 28).style("font-size", "14px").style("font-weight", "700").style("fill", ctx.theme.textPrimary).text(ctx.prepared.title || "Relationship Matrix");
+    const layer = ctx.root.append("g").attr("class", "grid-relationship-matrix").attr("transform", `translate(${left},${top})`);
+    colIds.forEach((colId, colIndex) => {
+      layer.append("text").attr("x", headerSize + colIndex * cellSize + cellSize / 2).attr("y", 16).attr("text-anchor", "middle").attr("transform", `rotate(-35, ${headerSize + colIndex * cellSize + cellSize / 2}, 16)`).style("font-size", "9px").style("fill", ctx.theme.textSecondary).text(shortMatrixLabel(colId));
+    });
+    rowIds.forEach((rowId, rowIndex) => {
+      layer.append("text").attr("x", headerSize - 8).attr("y", headerSize + rowIndex * cellSize + cellSize / 2 + 4).attr("text-anchor", "end").style("font-size", "10px").style("fill", ctx.theme.textPrimary).text(shortMatrixLabel(rowId));
+      colIds.forEach((colId, colIndex) => {
+        const cell = matrixCells.find(
+          (entry) => asString(entry.source) === rowId && asString(entry.target) === colId
+        );
+        const labels = asArray(cell?.labels).map((value) => asString(value)).filter(Boolean);
+        const present = labels.length > 0;
+        const x2 = headerSize + colIndex * cellSize;
+        const y2 = headerSize + rowIndex * cellSize;
+        const cellGroup = layer.append("g").attr("class", "grid-relationship-matrix-cell").attr("data-row-id", rowId).attr("data-col-id", colId);
+        cellGroup.append("rect").attr("x", x2).attr("y", y2).attr("width", cellSize - 2).attr("height", cellSize - 2).style("fill", present ? ctx.theme.nodeFill : ctx.theme.canvasBackground).style("stroke", ctx.theme.nodeBorder).style("stroke-width", "1px");
+        if (present) {
+          const dotSpacing = 10;
+          const dotsWidth = (labels.length - 1) * dotSpacing;
+          const startX = x2 + (cellSize - 2) / 2 - dotsWidth / 2;
+          labels.forEach((_, labelIndex) => {
+            cellGroup.append("text").attr("x", startX + labelIndex * dotSpacing).attr("y", y2 + (cellSize - 2) / 2 + 4).attr("text-anchor", "middle").style("font-size", "12px").style("font-weight", "700").style("fill", ctx.theme.edge.default).text("\u25CF");
+          });
+          cellGroup.append("title").text(labels.join(", "));
+        }
+      });
+    });
+    const width = headerSize + colIds.length * cellSize + 40;
+    const height = headerSize + rowIds.length * cellSize + 40;
+    return { minX: 0, minY: 0, maxX: left + width, maxY: top + height };
+  }
+  function renderGeometryView(ctx) {
+    const elements = asArray(ctx.prepared.meta?.elements).map(asRecord);
+    const nodes = elements.length > 0 ? elements : ctx.prepared.nodes.map((node) => ({ id: node.id, label: node.label, kind: node.kind }));
+    const geometryMode = asString(ctx.prepared.meta?.geometryMode, "2d");
+    const geometryProjection = asString(ctx.prepared.meta?.geometryProjection, "orthographic");
+    const left = 64;
+    const top = 88;
+    const cellWidth = 128;
+    const cellHeight = 72;
+    const columns = Math.max(1, Math.ceil(Math.sqrt(nodes.length)));
+    ctx.root.append("text").attr("x", 24).attr("y", 28).style("font-size", "14px").style("font-weight", "700").style("fill", ctx.theme.textPrimary).text(ctx.prepared.title || "Geometry View");
+    if (Boolean(ctx.prepared.meta?.provisional)) {
+      drawProvisionalBadge(ctx.root, ctx.theme, `${geometryMode} ${geometryProjection} preview`);
+    }
+    const layer = ctx.root.append("g").attr("class", "geometry-view-scene").attr("transform", `translate(${left},${top})`);
+    layer.append("rect").attr("width", columns * cellWidth + 24).attr("height", Math.ceil(nodes.length / columns) * cellHeight + 24).attr("rx", 8).style("fill", "none").style("stroke", ctx.theme.frame.stroke).style("stroke-dasharray", "8,6");
+    nodes.forEach((node, index) => {
+      const col = index % columns;
+      const row = Math.floor(index / columns);
+      const x2 = col * cellWidth + 12;
+      const y2 = row * cellHeight + 12;
+      const preparedNode = nodeFromMeta(node, ctx.prepared.nodes);
+      const item = layer.append("g").attr("class", "geometry-object").attr("data-node-id", preparedNode?.id ?? asString(node.id, `geometry-node-${index}`)).attr("transform", `translate(${x2},${y2})`);
+      item.append("rect").attr("class", "node-background").attr("data-original-stroke", ctx.theme.nodeBorder).attr("data-original-width", "1.5px").attr("width", cellWidth - 20).attr("height", cellHeight - 16).attr("rx", 6).style("fill", ctx.theme.nodeFill).style("stroke", ctx.theme.nodeBorder).style("stroke-width", "1.5px");
+      item.append("text").attr("x", (cellWidth - 20) / 2).attr("y", 24).attr("text-anchor", "middle").style("font-size", "10px").style("font-weight", "700").style("fill", ctx.theme.textPrimary).text(truncateLabel(asString(node.label ?? node.name ?? node.id), 16));
+      item.append("text").attr("x", (cellWidth - 20) / 2).attr("y", 42).attr("text-anchor", "middle").style("font-size", "8px").style("fill", ctx.theme.textSecondary).text(truncateLabel(asString(node.kind, "element"), 18));
+      if (preparedNode) {
+        attachBehaviorNodeClick(item, preparedNode, ctx.theme, ctx.options ?? {}, ctx.root);
+      }
+    });
+    const width = columns * cellWidth + 80;
+    const height = Math.ceil(nodes.length / columns) * cellHeight + 120;
+    return { minX: 0, minY: 0, maxX: left + width, maxY: top + height };
+  }
+
+  // ../shared/diagram-renderer/src/render/types.ts
+  var nodeWidth = 200;
+  var nodeHeight = 70;
+  var ibdNodeWidth = 280;
+  var ibdNodeHeight = 140;
+  function contentBoundsFromExtents(extents) {
+    const width = extents.maxX - extents.minX;
+    const height = extents.maxY - extents.minY;
+    return {
+      x: extents.minX,
+      y: extents.minY,
+      width: width > 0 ? width : 1,
+      height: height > 0 ? height : 1
+    };
+  }
+  function compareIbdPorts(node, a, b, usageForPort) {
+    const usageA = usageForPort(node, a);
+    const usageB = usageForPort(node, b);
+    const degreeA = usageA.sourceCount + usageA.targetCount;
+    const degreeB = usageB.sourceCount + usageB.targetCount;
+    if (degreeB !== degreeA) return degreeB - degreeA;
+    return a.name.localeCompare(b.name);
+  }
+  function splitIbdPortsBySide(node, ports, sideForPort, usageForPort) {
+    const west = [];
+    const east = [];
+    for (const port of ports) {
+      (sideForPort(port, node) === "WEST" ? west : east).push(port);
+    }
+    const compare = (a, b) => compareIbdPorts(node, a, b, usageForPort);
+    west.sort(compare);
+    east.sort(compare);
+    return { west, east };
+  }
+  function computeIbdLeafHeight(node, ports, portRows) {
+    const attrs = node.attributes ?? {};
+    const headerHeight = attrs.partType ? 50 : 38;
+    const children2 = Array.isArray(attrs.children) ? attrs.children : [];
+    const contentLineCount = children2.filter(
+      (child) => child && typeof child === "object" && String(child.name || "")
+    ).length;
+    const contentHeight = Math.min(contentLineCount, 8) * 12 + 10;
+    const portSpacing = 26;
+    const portsHeight = ports.length > 0 ? portRows * portSpacing + 22 : 0;
+    return Math.min(340, Math.max(ibdNodeHeight, headerHeight + contentHeight + portsHeight));
+  }
+
+  // ../shared/diagram-renderer/src/render/export.ts
+  function contentBounds(layout) {
+    if (!layout.nodes.length) return { x: 0, y: 0, width: 100, height: 100 };
+    const minX = Math.min(...layout.nodes.map((node) => node.x || 0));
+    const minY = Math.min(...layout.nodes.map((node) => node.y || 0));
+    const maxX = Math.max(...layout.nodes.map((node) => (node.x || 0) + (node.width || nodeWidth)));
+    const maxY = Math.max(...layout.nodes.map((node) => (node.y || 0) + (node.height || nodeHeight)));
+    return { x: minX, y: minY, width: maxX - minX, height: maxY - minY };
+  }
+  function applyFit(svg, zoom, root2, bounds, width, height, isInterconnectionView = false, delegateZoom = false) {
+    const padding = 48;
+    const minScale = isInterconnectionView ? 0.2 : 0.08;
+    const maxScale = isInterconnectionView ? 1.1 : 1.3;
+    const scale = Math.min(
+      maxScale,
+      Math.max(minScale, Math.min((width - padding * 2) / bounds.width, (height - padding * 2) / bounds.height))
+    );
+    const tx = (width - bounds.width * scale) / 2 - bounds.x * scale;
+    const ty = (height - bounds.height * scale) / 2 - bounds.y * scale;
+    const transform2 = identity2.translate(tx, ty).scale(scale);
+    if (delegateZoom) {
+      root2.attr("transform", transform2.toString());
+      return transform2;
+    }
+    svg.transition().duration(180).call(zoom.transform, transform2);
+    return transform2;
+  }
+  function addMarkers(svg, theme) {
+    const defs = svg.append("defs");
+    defs.append("marker").attr("id", "viz-arrow").attr("markerWidth", 10).attr("markerHeight", 10).attr("refX", 9).attr("refY", 3).attr("orient", "auto").attr("markerUnits", "strokeWidth").append("path").attr("d", "M0,0 L0,6 L9,3 z").attr("fill", theme.edge.default);
+    defs.append("marker").attr("id", "general-d3-arrow").attr("viewBox", "0 -5 10 10").attr("refX", 8).attr("refY", 0).attr("markerWidth", 5).attr("markerHeight", 5).attr("orient", "auto").append("path").attr("d", "M0,-4L10,0L0,4").style("fill", theme.edge.default);
+    defs.append("marker").attr("id", "general-d3-arrow-open").attr("viewBox", "0 -5 10 10").attr("refX", 9).attr("refY", 0).attr("markerWidth", 8).attr("markerHeight", 8).attr("orient", "auto").append("path").attr("d", "M0,-4L10,0L0,4").style("fill", "none").style("stroke", theme.edge.default).style("stroke-width", "1.3");
+    defs.append("marker").attr("id", "general-d3-specializes").attr("viewBox", "0 -6 12 12").attr("refX", 11).attr("refY", 0).attr("markerWidth", 8).attr("markerHeight", 8).attr("orient", "auto").append("path").attr("d", "M0,0L10,-4L10,4Z").style("fill", theme.nodeFill).style("stroke", theme.edge.default).style("stroke-width", "1.2");
+    defs.append("marker").attr("id", "general-d3-diamond").attr("viewBox", "0 -6 12 12").attr("refX", 2).attr("refY", 0).attr("markerWidth", 7).attr("markerHeight", 7).attr("orient", "auto").append("path").attr("d", "M0,0L5,-4L10,0L5,4Z").style("fill", theme.edge.default);
+    defs.append("marker").attr("id", "ibd-connection-dot").attr("viewBox", "-5 -5 10 10").attr("refX", 0).attr("refY", 0).attr("markerWidth", 5).attr("markerHeight", 5).attr("orient", "auto").append("circle").attr("r", 3).style("fill", theme.nodeFill).style("stroke", theme.edge.default).style("stroke-width", "1.5");
+    defs.append("marker").attr("id", "ibd-flow-arrow").attr("viewBox", "0 -5 10 10").attr("refX", 10).attr("refY", 0).attr("markerWidth", 8).attr("markerHeight", 8).attr("orient", "auto").append("path").attr("d", "M0,-4L10,0L0,4Z").style("fill", theme.edge.default);
+    defs.append("marker").attr("id", "ibd-interface-arrow").attr("viewBox", "0 -5 10 10").attr("refX", 10).attr("refY", 0).attr("markerWidth", 8).attr("markerHeight", 8).attr("orient", "auto").append("path").attr("d", "M0,-4L10,0L0,4Z").style("fill", "none").style("stroke", theme.edge.default).style("stroke-width", "1.5");
+  }
+  function exportSvg(svgNode2, bounds) {
+    const clone = svgNode2.cloneNode(true);
+    clone.setAttribute("xmlns", "http://www.w3.org/2000/svg");
+    clone.setAttribute("viewBox", `${bounds.x - 40} ${bounds.y - 40} ${bounds.width + 80} ${bounds.height + 80}`);
+    return new XMLSerializer().serializeToString(clone);
   }
 
   // ../shared/diagram-renderer/src/render/ibd-route.ts

--- a/crates/sysml_model/src/semantic/graph.rs
+++ b/crates/sysml_model/src/semantic/graph.rs
@@ -917,6 +917,29 @@ impl SemanticGraphData {
             .collect()
     }
 
+    /// Returns structural interconnection edges (`connect` and `bind`) incident to nodes in the
+    /// given URI. Kept separate from `connection_edges_touching_uri` because callers performing
+    /// connection type compatibility checks must not treat bindings as connections.
+    pub fn interconnection_edges_touching_uri(
+        &self,
+        uri: &Url,
+    ) -> Vec<(NodeId, NodeId, SemanticEdge)> {
+        let indexes = self.query_indexes();
+        indexes
+            .edges_by_uri
+            .get(uri)
+            .into_iter()
+            .flatten()
+            .filter(|(_, _, edge)| {
+                matches!(
+                    edge.kind,
+                    RelationshipKind::Connection | RelationshipKind::Bind
+                )
+            })
+            .cloned()
+            .collect()
+    }
+
     /// Returns `Connection` edges declared in the given URI with `connect` metadata.
     pub fn connect_statement_edges_for_uri(
         &self,

--- a/crates/sysml_model/src/semantic/graph_builder/expressions.rs
+++ b/crates/sysml_model/src/semantic/graph_builder/expressions.rs
@@ -121,12 +121,32 @@ fn add_expression_edge_with_metadata(
     if left_str.is_empty() || right_str.is_empty() {
         return;
     }
-    if kind == RelationshipKind::Connection {
+    if matches!(kind, RelationshipKind::Connection | RelationshipKind::Bind) {
         let left_resolved = resolve_expression_endpoint_strict(g, uri, container_prefix, &left_str);
         let right_resolved =
             resolve_expression_endpoint_strict(g, uri, container_prefix, &right_str);
         match (left_resolved, right_resolved) {
             (ResolveResult::Resolved(src_id), ResolveResult::Resolved(tgt_id)) => {
+                if kind == RelationshipKind::Bind {
+                    add_semantic_edge_once(
+                        g,
+                        &src_id,
+                        &tgt_id,
+                        SemanticEdge::interconnection_with_detail(
+                            kind,
+                            ConnectStatementDetail {
+                                declaring_uri: uri.clone(),
+                                range: span_to_range(&left.span),
+                                source_expression: left_str,
+                                target_expression: right_str,
+                                container_prefix: container_prefix.map(ToString::to_string),
+                                is_interface_usage,
+                                interface_type,
+                            },
+                        ),
+                    );
+                    return;
+                }
                 if add_semantic_edge_once(
                     g,
                     &src_id,

--- a/crates/sysml_model/src/semantic/graph_builder/part_def.rs
+++ b/crates/sysml_model/src/semantic/graph_builder/part_def.rs
@@ -503,6 +503,16 @@ pub(super) fn build_from_part_def_body_element(
                 RelationshipKind::Allocate,
             );
         }
+        PDBE::Bind(bind_node) => {
+            expressions::add_expression_edge_if_both_exist(
+                g,
+                uri,
+                container_prefix,
+                &bind_node.value.left,
+                &bind_node.value.right,
+                RelationshipKind::Bind,
+            );
+        }
         PDBE::Ref(r) => {
             super::ref_decl::materialize_ref_decl(
                 g,

--- a/crates/sysml_model/src/semantic/ibd/connectors.rs
+++ b/crates/sysml_model/src/semantic/ibd/connectors.rs
@@ -339,6 +339,17 @@ pub(crate) struct IbdConnectorSink<'a> {
     pub(crate) keys: &'a mut std::collections::HashSet<(String, String, String)>,
 }
 
+pub(crate) fn is_interconnection_relationship(kind: &RelationshipKind) -> bool {
+    matches!(kind, RelationshipKind::Connection | RelationshipKind::Bind)
+}
+
+pub(crate) fn interconnection_relation_type(kind: &RelationshipKind) -> &'static str {
+    match kind {
+        RelationshipKind::Bind => "binding",
+        _ => "connection",
+    }
+}
+
 /// Copy connectors declared on a part definition's document onto a typed instance path.
 pub(crate) fn mirror_connectors_from_definition_document(
     graph: &SemanticGraph,
@@ -352,7 +363,7 @@ pub(crate) fn mirror_connectors_from_definition_document(
     let def_prefix_dot = qualified_name_to_dot(def_prefix);
     let def_container_prefixes = def_container_prefixes_for_uri(graph, def_uri);
 
-    let mut push_connector = |source_id: String, target_id: String| {
+    let mut push_connector = |source_id: String, target_id: String, rel_type: &str| {
         let source_id = expand_relative_endpoint_to_part_path(&source_id, parts, ports);
         let target_id = expand_relative_endpoint_to_part_path(&target_id, parts, ports);
         let source_id =
@@ -361,11 +372,7 @@ pub(crate) fn mirror_connectors_from_definition_document(
         let target_id =
             map_container_endpoint_to_instance(&target_id, &def_prefix_dot, usage_prefix_dot)
                 .unwrap_or(target_id);
-        let key = (
-            source_id.clone(),
-            target_id.clone(),
-            "connection".to_string(),
-        );
+        let key = (source_id.clone(), target_id.clone(), rel_type.to_string());
         if !sink.keys.insert(key) {
             return;
         }
@@ -378,14 +385,12 @@ pub(crate) fn mirror_connectors_from_definition_document(
             target_part_id: None,
             source_port_id: None,
             target_port_id: None,
-            rel_type: "connection".to_string(),
+            rel_type: rel_type.to_string(),
         });
     };
 
-    for (_src, _tgt, edge) in graph.connection_edges_touching_uri(def_uri) {
-        if edge.kind != RelationshipKind::Connection {
-            continue;
-        }
+    for (_src, _tgt, edge) in graph.interconnection_edges_touching_uri(def_uri) {
+        let rel_type = interconnection_relation_type(&edge.kind);
         let Some(connect) = &edge.connect else {
             continue;
         };
@@ -405,13 +410,13 @@ pub(crate) fn mirror_connectors_from_definition_document(
         } else {
             (source_id, target_id)
         };
-        push_connector(source_id, target_id);
+        push_connector(source_id, target_id, rel_type);
     }
 
     for pending in graph
         .pending_expression_relationships
         .iter()
-        .filter(|pending| pending.kind == RelationshipKind::Connection && pending.uri == *def_uri)
+        .filter(|pending| is_interconnection_relationship(&pending.kind) && pending.uri == *def_uri)
     {
         let source_id = qualify_pending_connection_endpoint(
             pending.container_prefix.as_deref(),
@@ -424,11 +429,15 @@ pub(crate) fn mirror_connectors_from_definition_document(
         if source_id.is_empty() || target_id.is_empty() {
             continue;
         }
-        push_connector(source_id, target_id);
+        push_connector(
+            source_id,
+            target_id,
+            interconnection_relation_type(&pending.kind),
+        );
     }
 
-    for (src_id, tgt_id, edge) in graph.connection_edges_touching_uri(def_uri) {
-        if edge.kind != RelationshipKind::Connection || edge.connect.is_some() {
+    for (src_id, tgt_id, edge) in graph.interconnection_edges_touching_uri(def_uri) {
+        if edge.connect.is_some() {
             continue;
         }
         let src = src_id.qualified_name;
@@ -446,7 +455,11 @@ pub(crate) fn mirror_connectors_from_definition_document(
         else {
             continue;
         };
-        push_connector(source_id, target_id);
+        push_connector(
+            source_id,
+            target_id,
+            interconnection_relation_type(&edge.kind),
+        );
     }
 }
 pub fn finalize_merged_ibd_connectors(

--- a/crates/sysml_model/src/semantic/ibd/extract_impl.rs
+++ b/crates/sysml_model/src/semantic/ibd/extract_impl.rs
@@ -7,16 +7,16 @@ use url::Url;
 
 use super::connectors::{
     build_instance_def_mappings, dedupe_connectors, endpoint_under_definition_prefix,
-    enrich_connector_endpoint_refs, map_definition_endpoint_to_usage,
-    mirror_connectors_from_definition_document, remap_connectors_to_typed_instances,
-    IbdConnectorSink,
+    enrich_connector_endpoint_refs, interconnection_relation_type, is_interconnection_relationship,
+    map_definition_endpoint_to_usage, mirror_connectors_from_definition_document,
+    remap_connectors_to_typed_instances, IbdConnectorSink,
 };
 use super::dto::{
     DefInstanceMappingDto, IbdConnectorDto, IbdContainerGroupDto, IbdDataDto, IbdPartDto,
     IbdPortDto, IbdRootViewDto,
 };
 use crate::semantic::kinds;
-use crate::{ElementKind, NodeId, RelationshipKind, SemanticGraph, SemanticNode};
+use crate::{ElementKind, NodeId, SemanticGraph, SemanticNode};
 
 mod container_groups;
 mod endpoint_expansion;
@@ -275,10 +275,7 @@ pub fn build_ibd_for_uri(graph: &SemanticGraph, uri: &Url) -> IbdDataDto {
         .collect();
 
     let mut connectors = Vec::new();
-    for (src_id, tgt_id, edge) in graph.connection_edges_touching_uri(uri) {
-        if edge.kind != RelationshipKind::Connection {
-            continue;
-        }
+    for (src_id, tgt_id, edge) in graph.interconnection_edges_touching_uri(uri) {
         let source = src_id.qualified_name.clone();
         let target = tgt_id.qualified_name.clone();
         let (source_id, target_id) = if let Some(connect) = &edge.connect {
@@ -311,13 +308,13 @@ pub fn build_ibd_for_uri(graph: &SemanticGraph, uri: &Url) -> IbdDataDto {
             target_part_id: None,
             source_port_id: None,
             target_port_id: None,
-            rel_type: "connection".to_string(),
+            rel_type: interconnection_relation_type(&edge.kind).to_string(),
         });
     }
     for pending in graph
         .pending_expression_relationships
         .iter()
-        .filter(|pending| pending.kind == RelationshipKind::Connection && &pending.uri == uri)
+        .filter(|pending| is_interconnection_relationship(&pending.kind) && &pending.uri == uri)
     {
         let source_id = qualify_pending_connection_endpoint(
             pending.container_prefix.as_deref(),
@@ -339,7 +336,7 @@ pub fn build_ibd_for_uri(graph: &SemanticGraph, uri: &Url) -> IbdDataDto {
             target_part_id: None,
             source_port_id: None,
             target_port_id: None,
-            rel_type: "connection".to_string(),
+            rel_type: interconnection_relation_type(&pending.kind).to_string(),
         });
     }
 
@@ -369,11 +366,17 @@ pub fn build_ibd_for_uri(graph: &SemanticGraph, uri: &Url) -> IbdDataDto {
             );
             continue;
         }
-        let def_edges = graph.edges_for_uri_as_strings(&def_id.uri);
-        for (src, tgt, kind, _name) in &def_edges {
-            if *kind != RelationshipKind::Connection {
+        let def_edges = graph.interconnection_edges_touching_uri(&def_id.uri);
+        for (src_id, tgt_id, edge) in &def_edges {
+            // Expression-backed relationships were already collected above with their declaring
+            // context intact. Re-mirroring their resolved definition endpoints can collapse a
+            // usage-to-boundary binding into a bogus self-binding.
+            if edge.connect.is_some() {
                 continue;
             }
+            let src = &src_id.qualified_name;
+            let tgt = &tgt_id.qualified_name;
+            let kind = &edge.kind;
             if !endpoint_under_definition_prefix(src, def_prefix)
                 || !endpoint_under_definition_prefix(tgt, def_prefix)
             {
@@ -392,7 +395,7 @@ pub fn build_ibd_for_uri(graph: &SemanticGraph, uri: &Url) -> IbdDataDto {
             let key = (
                 source_id.clone(),
                 target_id.clone(),
-                "connection".to_string(),
+                interconnection_relation_type(kind).to_string(),
             );
             if !connector_keys.insert(key) {
                 continue;
@@ -406,7 +409,7 @@ pub fn build_ibd_for_uri(graph: &SemanticGraph, uri: &Url) -> IbdDataDto {
                 target_part_id: None,
                 source_port_id: None,
                 target_port_id: None,
-                rel_type: "connection".to_string(),
+                rel_type: interconnection_relation_type(kind).to_string(),
             });
         }
     }

--- a/crates/sysml_model/src/semantic/model.rs
+++ b/crates/sysml_model/src/semantic/model.rs
@@ -571,7 +571,8 @@ pub struct FlowStatementDetail {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SemanticEdge {
     pub kind: RelationshipKind,
-    /// Set when this `Connection` came from a resolved `connect` (or pending-expression resolve).
+    /// Set when a structural expression relationship (`connect` or `bind`) was resolved, retaining
+    /// its declaring context and endpoint expressions for instance projection.
     pub connect: Option<ConnectStatementDetail>,
     /// Set when this `Flow`/`SuccessionFlow` came from a resolved `flow` usage.
     #[serde(default)]
@@ -590,6 +591,17 @@ impl SemanticEdge {
     pub fn connection_with_connect(connect: ConnectStatementDetail) -> Self {
         Self {
             kind: RelationshipKind::Connection,
+            connect: Some(connect),
+            flow: None,
+        }
+    }
+
+    pub fn interconnection_with_detail(
+        kind: RelationshipKind,
+        connect: ConnectStatementDetail,
+    ) -> Self {
+        Self {
+            kind,
             connect: Some(connect),
             flow: None,
         }

--- a/crates/sysml_model/src/semantic/prepared_view/preparers/interconnection.rs
+++ b/crates/sysml_model/src/semantic/prepared_view/preparers/interconnection.rs
@@ -9,6 +9,43 @@ use crate::semantic::prepared_view::graph_norm::{
     is_definition_kind, is_reference_kind, normalize_edge_kind,
 };
 
+fn root_coverage(root_id: &str, scene: &InterconnectionSceneDto) -> usize {
+    let descendant_prefix = format!("{root_id}.");
+    scene
+        .nodes
+        .iter()
+        .filter(|node| node.id == root_id || node.id.starts_with(&descendant_prefix))
+        .count()
+}
+
+fn selected_root(scene: &InterconnectionSceneDto) -> Option<&str> {
+    scene
+        .view
+        .root_ids
+        .iter()
+        .max_by(|left, right| {
+            root_coverage(left, scene)
+                .cmp(&root_coverage(right, scene))
+                .then_with(|| right.matches('.').count().cmp(&left.matches('.').count()))
+                .then_with(|| right.cmp(left))
+        })
+        .map(String::as_str)
+}
+
+fn container_is_in_selected_scope(
+    container_id: &str,
+    root: Option<&str>,
+    has_coverage: bool,
+) -> bool {
+    if !has_coverage {
+        return true;
+    }
+    let Some(root) = root else {
+        return true;
+    };
+    container_id == root || container_id.starts_with(&format!("{root}."))
+}
+
 pub fn prepare_interconnection_prepared_view(
     response: &SysmlVisualizationResultDto,
 ) -> Result<PreparedViewDto, String> {
@@ -23,6 +60,10 @@ pub fn prepare_interconnection_scene(
     scene: &InterconnectionSceneDto,
     response: &SysmlVisualizationResultDto,
 ) -> PreparedViewDto {
+    let selected_root = selected_root(scene);
+    let selected_root_has_coverage = selected_root
+        .map(|root| root_coverage(root, scene) > 0)
+        .unwrap_or(false);
     let mut node_ids: std::collections::HashSet<String> =
         scene.nodes.iter().map(|node| node.id.clone()).collect();
     let mut nodes: Vec<PreparedNodeDto> = scene
@@ -78,7 +119,13 @@ pub fn prepare_interconnection_scene(
         .collect();
 
     for container in &scene.containers {
-        if node_ids.contains(&container.id) {
+        if node_ids.contains(&container.id)
+            || !container_is_in_selected_scope(
+                &container.id,
+                selected_root,
+                selected_root_has_coverage,
+            )
+        {
             continue;
         }
         nodes.push(PreparedNodeDto {
@@ -144,7 +191,8 @@ pub fn prepare_interconnection_scene(
         meta: Some(json!({
             "canonicalScene": true,
             "schemaVersion": scene.schema_version,
-            "selectedRoot": scene.view.root_ids.first(),
+            "selectedRoot": selected_root,
+            "rootCandidates": scene.view.root_ids,
         })),
     }
 }

--- a/crates/sysml_model/src/semantic/relationships/pending.rs
+++ b/crates/sysml_model/src/semantic/relationships/pending.rs
@@ -213,20 +213,29 @@ fn resolve_pending_expression_relationships_for_uri(g: &mut SemanticGraph, uri: 
                 continue;
             }
         };
-        if pending_edge.kind == RelationshipKind::Connection {
+        if matches!(
+            pending_edge.kind,
+            RelationshipKind::Connection | RelationshipKind::Bind
+        ) {
+            let kind = pending_edge.kind.clone();
+            let detail = ConnectStatementDetail {
+                declaring_uri: uri.clone(),
+                range: pending_edge.source_range,
+                source_expression: pending_edge.source_expression,
+                target_expression: pending_edge.target_expression,
+                container_prefix: pending_edge.container_prefix.clone(),
+                is_interface_usage: pending_edge.is_interface_usage,
+                interface_type: pending_edge.interface_type,
+            };
             add_semantic_edge_once(
                 g,
                 &source_id,
                 &target_id,
-                SemanticEdge::connection_with_connect(ConnectStatementDetail {
-                    declaring_uri: uri.clone(),
-                    range: pending_edge.source_range,
-                    source_expression: pending_edge.source_expression,
-                    target_expression: pending_edge.target_expression,
-                    container_prefix: pending_edge.container_prefix.clone(),
-                    is_interface_usage: pending_edge.is_interface_usage,
-                    interface_type: pending_edge.interface_type,
-                }),
+                if kind == RelationshipKind::Connection {
+                    SemanticEdge::connection_with_connect(detail)
+                } else {
+                    SemanticEdge::interconnection_with_detail(kind, detail)
+                },
             );
         } else {
             add_semantic_edge_once(

--- a/crates/sysml_model/src/semantic/visualization/response.rs
+++ b/crates/sysml_model/src/semantic/visualization/response.rs
@@ -559,7 +559,7 @@ pub fn build_sysml_visualization_from_artifacts(
     );
     let scene_start = Instant::now();
     let interconnection_scene = if resolved_view == "interconnection-view" {
-        let root_ids = selected_evaluated
+        let mut root_ids = selected_evaluated
             .map(|evaluated| {
                 evaluated
                     .exposed_ids
@@ -569,6 +569,12 @@ pub fn build_sysml_visualization_from_artifacts(
             })
             .filter(|ids| !ids.is_empty())
             .unwrap_or_else(|| filtered_ibd.root_candidates.clone());
+        root_ids.sort_by(|left, right| {
+            left.matches('.')
+                .count()
+                .cmp(&right.matches('.').count())
+                .then_with(|| left.cmp(right))
+        });
         Some(build_interconnection_scene(
             &filtered_ibd,
             &selected_view_id,

--- a/crates/sysml_model/tests/part_def_body_semantics.rs
+++ b/crates/sysml_model/tests/part_def_body_semantics.rs
@@ -419,10 +419,16 @@ fn part_def_body_bind_emits_bind_edge_between_nested_features() {
     let doc = workspace_doc(
         "part_def_bind.sysml",
         r#"package P {
-  part def Assembly {
-    part source;
-    part target;
-    bind source = target;
+  port def SignalPort;
+  part def Component {
+    port internalPort : SignalPort;
+  }
+  part def Boundary {
+    port boundaryPort : SignalPort;
+  }
+  part def Assembly :> Boundary {
+    part component : Component;
+    bind boundaryPort = component.internalPort;
   }
 }"#,
     );
@@ -438,11 +444,11 @@ fn part_def_body_bind_emits_bind_edge_between_nested_features() {
     assert_eq!(bind_edges.len(), 1, "expected exactly one Bind edge");
     let (source, target, _, _) = &bind_edges[0];
     assert!(
-        source.ends_with("::Assembly::source"),
+        source.ends_with("::Boundary::boundaryPort"),
         "unexpected bind source: {source}"
     );
     assert!(
-        target.ends_with("::Assembly::target"),
+        target.ends_with("::Component::internalPort"),
         "unexpected bind target: {target}"
     );
 }

--- a/crates/sysml_model/tests/part_def_body_semantics.rs
+++ b/crates/sysml_model/tests/part_def_body_semantics.rs
@@ -413,3 +413,36 @@ fn occurrence_def_body_flow_emits_flow_edge() {
         .any(|(_, _, k, _)| *k == RelationshipKind::Flow);
     assert!(has_flow, "expected Flow edge from occurrence def body flow");
 }
+
+#[test]
+fn part_def_body_bind_emits_bind_edge_between_nested_features() {
+    let doc = workspace_doc(
+        "part_def_bind.sysml",
+        r#"package P {
+  part def Assembly {
+    part source;
+    part target;
+    bind source = target;
+  }
+}"#,
+    );
+    let uri = doc.uri.clone();
+    let (graph, _parsed) = build_semantic_graph_from_documents(&[doc]).expect("graph");
+
+    let bind_edges: Vec<_> = graph
+        .edges_for_uri_as_strings(&uri)
+        .into_iter()
+        .filter(|(_, _, kind, _)| *kind == RelationshipKind::Bind)
+        .collect();
+
+    assert_eq!(bind_edges.len(), 1, "expected exactly one Bind edge");
+    let (source, target, _, _) = &bind_edges[0];
+    assert!(
+        source.ends_with("::Assembly::source"),
+        "unexpected bind source: {source}"
+    );
+    assert!(
+        target.ends_with("::Assembly::target"),
+        "unexpected bind target: {target}"
+    );
+}

--- a/crates/sysml_tokens/src/ast_ranges.rs
+++ b/crates/sysml_tokens/src/ast_ranges.rs
@@ -1015,6 +1015,7 @@ fn collect_semantic_ranges_part_def_body_element(
         PDBE::Connect(_)
         | PDBE::InterfaceUsage(_)
         | PDBE::Allocate(_)
+        | PDBE::Bind(_)
         | PDBE::OpaqueMember(_)
         | PDBE::Annotation(_)
         | PDBE::Error(_)

--- a/shared/diagram-renderer/src/prepare.test.ts
+++ b/shared/diagram-renderer/src/prepare.test.ts
@@ -432,6 +432,36 @@ describe("shared prepareViewData", () => {
     expect(prepared.edges[1]?.target).toBe("WebShopBehavior::CheckoutPipeline::reserveInventory");
   });
 
+  it("distinguishes streaming flows from successions", () => {
+    const prepared = prepareViewData({
+      view: "action-flow-view",
+      activityDiagrams: [{
+        id: "Demo::Behavior",
+        name: "Behavior",
+        actions: [
+          { id: "Demo::Behavior::a", name: "a", type: "action" },
+          { id: "Demo::Behavior::b", name: "b", type: "action" },
+          { id: "Demo::Behavior::c", name: "c", type: "action" },
+        ],
+        flows: [
+          { id: "stream", from: "a", to: "b", guard: "flow" },
+          { id: "sequence", from: "b", to: "c", guard: "succession" },
+        ],
+      }],
+    });
+
+    expect(prepared.edges[0]?.attributes).toMatchObject({
+      streamingFlow: true,
+      succession: false,
+      flowKind: "streaming",
+    });
+    expect(prepared.edges[1]?.attributes).toMatchObject({
+      streamingFlow: false,
+      succession: true,
+      flowKind: "succession",
+    });
+  });
+
   it("matches action-flow diagram when view usage name differs in case from diagram name", () => {
     const prepared = prepareViewData({
       view: "action-flow-view",

--- a/shared/diagram-renderer/src/prepare/behavior/action-flow.ts
+++ b/shared/diagram-renderer/src/prepare/behavior/action-flow.ts
@@ -117,7 +117,8 @@ export function prepareActivity(visualization: VisualizationPayload): PreparedVi
       const guard = asString(edge.guard ?? edge.type, "");
       const condition = asString(edge.condition, "");
       const guardLower = guard.toLowerCase();
-      const succession = guardLower === "flow" || guardLower === "first" || guardLower === "succession";
+      const succession = guardLower === "first" || guardLower === "succession" || guardLower === "succession flow";
+      const streamingFlow = guardLower === "flow";
       const conditional =
         condition.length > 0
         || (guard.length > 0 && !["flow", "first", "bind", "perform", "succession"].includes(guardLower));
@@ -130,6 +131,8 @@ export function prepareActivity(visualization: VisualizationPayload): PreparedVi
           ...(guard ? { guard } : {}),
           ...(condition ? { condition } : {}),
           succession,
+          streamingFlow,
+          flowKind: succession ? "succession" : streamingFlow ? "streaming" : "other",
           conditional,
         },
       };

--- a/shared/diagram-renderer/src/prepare/interconnection-scene.test.ts
+++ b/shared/diagram-renderer/src/prepare/interconnection-scene.test.ts
@@ -21,4 +21,44 @@ describe("prepareInterconnectionScene", () => {
       },
     });
   });
+
+  it("selects the materialized instance root, prunes ancestor packages, and preserves bindings", () => {
+    const scene = {
+      schemaVersion: 2,
+      view: {
+        id: "architecture",
+        name: "Architecture",
+        type: "InterconnectionView",
+        rootIds: ["occ:Demo.SystemDef.child", "occ:Demo.system"],
+      },
+      nodes: [
+        { id: "occ:Demo.system.left", semanticId: "Demo.system.left", qualifiedName: "Demo.system.left", name: "left", kind: "part" },
+        { id: "occ:Demo.system.right", semanticId: "Demo.system.right", qualifiedName: "Demo.system.right", name: "right", kind: "part" },
+      ],
+      ports: [
+        { id: "occ:Demo.system.left.out", semanticId: "Demo.system.left.out", ownerNodeId: "occ:Demo.system.left", name: "out", sideHint: "east" },
+        { id: "occ:Demo.system.right.in", semanticId: "Demo.system.right.in", ownerNodeId: "occ:Demo.system.right", name: "in", sideHint: "west" },
+      ],
+      edges: [{
+        id: "binding-1",
+        kind: "binding",
+        sourcePortId: "occ:Demo.system.left.out",
+        targetPortId: "occ:Demo.system.right.in",
+        sourceNodeId: "occ:Demo.system.left",
+        targetNodeId: "occ:Demo.system.right",
+      }],
+      containers: [
+        { id: "occ:Demo", label: "Demo", memberNodeIds: ["occ:Demo.system.left", "occ:Demo.system.right"], depth: 0 },
+        { id: "occ:Demo.system", label: "system", memberNodeIds: ["occ:Demo.system.left", "occ:Demo.system.right"], depth: 1 },
+      ],
+      diagnostics: [],
+    };
+
+    const prepared = prepareInterconnectionScene(scene, { interconnectionScene: scene });
+    expect(prepared.meta?.selectedRoot).toBe("occ:Demo.system");
+    expect(prepared.nodes.some((node) => node.id === "occ:Demo")).toBe(false);
+    expect(prepared.nodes.some((node) => node.id === "occ:Demo.system")).toBe(true);
+    expect(prepared.edges).toHaveLength(1);
+    expect(prepared.edges[0]?.edgeKind).toBe("bind");
+  });
 });

--- a/shared/diagram-renderer/src/prepare/interconnection-scene.ts
+++ b/shared/diagram-renderer/src/prepare/interconnection-scene.ts
@@ -34,10 +34,27 @@ function mapPortDetail(port: InterconnectionScenePortDto) {
   };
 }
 
+function rootCoverage(rootId: string, scene: InterconnectionSceneDto): number {
+  const prefix = `${rootId}.`;
+  return scene.nodes.filter((node) => node.id === rootId || node.id.startsWith(prefix)).length;
+}
+
+function selectRoot(scene: InterconnectionSceneDto): string | null {
+  return [...scene.view.rootIds].sort((left, right) => {
+    const coverageDelta = rootCoverage(right, scene) - rootCoverage(left, scene);
+    if (coverageDelta !== 0) return coverageDelta;
+    const depthDelta = left.split(".").length - right.split(".").length;
+    if (depthDelta !== 0) return depthDelta;
+    return left.localeCompare(right);
+  })[0] ?? null;
+}
+
 export function prepareInterconnectionScene(
   scene: InterconnectionSceneDto,
   visualization: VisualizationPayload,
 ): InterconnectionPreparedView {
+  const selectedRoot = selectRoot(scene);
+  const selectedRootHasCoverage = selectedRoot !== null && rootCoverage(selectedRoot, scene) > 0;
   const nodeIds = new Set(scene.nodes.map((node) => node.id));
   const nodes: InterconnectionPreparedNode[] = scene.nodes.map((node) => {
     const nodePorts = portsForNode(node.id, scene.ports);
@@ -64,7 +81,11 @@ export function prepareInterconnectionScene(
   });
 
   for (const container of scene.containers) {
-    if (nodeIds.has(container.id)) continue;
+    const inSelectedScope = !selectedRootHasCoverage
+      || selectedRoot === null
+      || container.id === selectedRoot
+      || container.id.startsWith(`${selectedRoot}.`);
+    if (nodeIds.has(container.id) || !inSelectedScope) continue;
     nodes.push({
       id: container.id,
       label: container.label,
@@ -111,7 +132,7 @@ export function prepareInterconnectionScene(
     meta: {
       canonicalScene: true,
       schemaVersion: scene.schemaVersion,
-      selectedRoot: scene.view.rootIds[0] ?? null,
+      selectedRoot,
       rootCandidates: scene.view.rootIds,
       diagnostics: scene.diagnostics,
     },

--- a/shared/diagram-renderer/src/renderer.test.ts
+++ b/shared/diagram-renderer/src/renderer.test.ts
@@ -1135,6 +1135,33 @@ describe("shared renderer", () => {
     expect(target.querySelectorAll(".action-flow-edge").length).toBeGreaterThanOrEqual(2);
   });
 
+  it("renders streaming flows solid and successions dashed", async () => {
+    const target = document.createElement("div");
+    Object.defineProperty(target, "clientWidth", { value: 1200, configurable: true });
+    Object.defineProperty(target, "clientHeight", { value: 800, configurable: true });
+
+    await renderVisualization(target, {
+      title: "Flow semantics",
+      view: "action-flow-view",
+      nodes: [
+        { id: "a", label: "a", kind: "action" },
+        { id: "b", label: "b", kind: "action" },
+        { id: "c", label: "c", kind: "action" },
+      ],
+      edges: [
+        { id: "stream", source: "a", target: "b", label: "flow", attributes: { guard: "flow", streamingFlow: true } },
+        { id: "sequence", source: "b", target: "c", label: "succession", attributes: { guard: "succession", succession: true } },
+      ],
+    });
+
+    const streaming = target.querySelector('[data-flow-kind="streaming"]') as SVGPathElement;
+    const succession = target.querySelector('[data-flow-kind="succession"]') as SVGPathElement;
+    expect(streaming?.getAttribute("class")).toContain("aflow-streaming");
+    expect(streaming?.style.strokeDasharray).toBe("none");
+    expect(succession?.getAttribute("class")).toContain("aflow-succession");
+    expect(succession?.style.strokeDasharray).toBe("7,4");
+  });
+
   it("renders action-flow perform actions with parameter badges and flow final notation", async () => {
     const target = document.createElement("div");
     Object.defineProperty(target, "clientWidth", { value: 1200, configurable: true });

--- a/shared/diagram-renderer/src/views/action-flow.ts
+++ b/shared/diagram-renderer/src/views/action-flow.ts
@@ -237,7 +237,8 @@ export async function renderActionFlowView(ctx: BehaviorSceneContext): Promise<{
     const fallback = fallbackEdgePath(source, target, horizontal);
     const edgeAttrs = (edge.attributes ?? {}) as Record<string, unknown>;
     const guard = String(edgeAttrs.guard ?? edge.label ?? "").toLowerCase();
-    const succession = Boolean(edgeAttrs.succession) || guard === "flow" || guard === "first" || guard === "succession";
+    const succession = Boolean(edgeAttrs.succession) || guard === "first" || guard === "succession" || guard === "succession flow";
+    const streamingFlow = Boolean(edgeAttrs.streamingFlow) || guard === "flow";
     const conditional = Boolean(edgeAttrs.conditional);
     flowLayer
       .append("path")
@@ -247,12 +248,16 @@ export async function renderActionFlowView(ctx: BehaviorSceneContext): Promise<{
           ? conditional
             ? "activity-flow action-flow-edge aflow-succession aflow-conditional"
             : "activity-flow action-flow-edge aflow-succession"
-          : "activity-flow action-flow-edge",
+          : streamingFlow
+            ? "activity-flow action-flow-edge aflow-streaming"
+            : "activity-flow action-flow-edge",
       )
+      .attr("data-flow-kind", succession ? "succession" : streamingFlow ? "streaming" : "other")
       .attr("d", pathFromSections(sections) || fallback.path)
       .style("fill", "none")
       .style("stroke", ctx.theme.edge.default)
       .style("stroke-width", "2px")
+      .style("stroke-dasharray", succession ? "7,4" : "none")
       .style("marker-end", "url(#action-flow-arrow)");
     const label = truncateLabel(edge.label, 20);
     if (label && !["flow", "first", "bind"].includes(label.toLowerCase())) {


### PR DESCRIPTION
## Summary
- update sysml-v2-parser from 0.51.1 to 0.51.7
- materialize definition-level bind statements as semantic Bind relationships
- cover inherited boundary features and typed nested member paths

## Validation
- cargo test -p sysml_model --test part_def_body_semantics
- cargo test -p sysml_model --lib
- cargo test -p lsp_server --test lsp_integration lsp_interconnection_visualization_projects_connections_to_typed_ref_parts -- --nocapture
- cargo check --workspace
- optical-transceiver project: 11 documents, 0 errors, 0 warnings; architecture view has 5 nodes and 2 internal connections