### PR TITLE
fix(tests): rewrite invalid succession fixture syntax

### DIFF
--- a/crates/sysml_model/tests/activity_graph_semantics.rs
+++ b/crates/sysml_model/tests/activity_graph_semantics.rs
@@ -160,16 +160,6 @@ fn enrich_does_not_promote_interface_parameters_to_action_steps() {
 }
 
 #[test]
-#[ignore = "this fixture's `succession validate to checkRoute of status == \"ok\";` line is not \
-            valid SysML v2 at all -- no `to`/`of` clause exists anywhere in the real \
-            `SuccessionAsUsage` grammar (OMG SysML v2.0 spec Sec.8.2.2.13.3). It happened to \
-            silently pass under sysml-v2-parser 0.50.0's more permissive handling; 0.51.1 \
-            correctly rejects it. The valid form (`succession name first A then B;`) is ALSO not \
-            yet supported by the parser -- tracked separately in \
-            https://github.com/elan8/sysml-v2-parser/issues/38, evidenced by real usage in the \
-            SysML v2 release library. This fixture itself needs rewriting to valid syntax once \
-            that lands, not just a parser fix -- tracked in \
-            https://github.com/elan8/spec42/issues/5."]
 fn ast_extract_includes_decision_merge_assign_and_conditional_succession() {
     let input = r#"package P {
   action def Route;
@@ -182,7 +172,7 @@ fn ast_extract_includes_decision_merge_assign_and_conditional_succession() {
       then action deliver : Deliver;
     }
     merge validate;
-    succession validate to checkRoute of status == "ok";
+    succession first validate then checkRoute;
   }
 }"#;
     let root = parse(input).expect("parse");


### PR DESCRIPTION
## Summary

- `ast_extract_includes_decision_merge_assign_and_conditional_succession`'s fixture used `succession validate to checkRoute of status == "ok";`, which is not valid SysML v2 -- no `to`/`of` clause exists in the `SuccessionAsUsage` grammar (OMG SysML v2.0 spec §8.2.2.13.3). It silently passed under sysml-v2-parser 0.50.0's permissive handling; 0.51.1 correctly rejected it, and the test was marked `#[ignore]` pending the `succession` keyword-prefix fix tracked in elan8/sysml-v2-parser#38.
- #38 has since landed and is included in the version already pinned here (0.51.7), so this fixture can now use the valid form.
- Rewritten to `succession first validate then checkRoute;` -- valid syntax expressing the same succession intent (from `validate` to `checkRoute`), and the `#[ignore]` removed.
- The guard-like `of status == "ok"` clause has no equivalent construct in the real grammar and isn't exercised by this test's assertions (which only check for a decision node, merge state, assign state, and for-loop state), so it's dropped rather than guessed at.

Fixes #5

## Test plan

- [x] `cargo test --package sysml_model --test activity_graph_semantics` -- 7/7 passing, 0 ignored
- [x] `cargo test --workspace -- --skip export_interconnection_scene_typescript_bindings` -- all passing (that one skipped test fails identically on unmodified `main`, a pre-existing CRLF/LF mismatch in a generated TypeScript binding file unrelated to this change)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` -- clean
- [x] `cargo fmt --check` -- clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)