### PR TITLE
ci: harden dependency audit, rustdoc lints, and toolchain pinning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ permissions:
 
 env:
   VSCODE_TEST_VERSION: "1.106.0"
+  # Keep in sync with `channel` in rust-toolchain.toml; bump both deliberately.
+  RUST_TOOLCHAIN_VERSION: "1.97.1"
 
 jobs:
   rust-core:
@@ -23,8 +25,9 @@ jobs:
           submodules: recursive
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}
           components: clippy
 
       - name: Cache cargo
@@ -125,6 +128,25 @@ jobs:
       - name: cargo clippy
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
+      - name: cargo doc
+        run: cargo doc --no-deps --workspace
+        env:
+          RUSTDOCFLAGS: -D warnings
+
+  audit:
+    name: Dependency audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
+
+      - name: cargo audit
+        run: cargo audit
+
   rust-surfaces:
     name: Rust agent/API surfaces
     runs-on: ubuntu-latest
@@ -134,7 +156,9 @@ jobs:
           submodules: recursive
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
@@ -233,6 +257,9 @@ jobs:
       - name: npm ci (diagram renderer)
         run: cd shared/diagram-renderer && npm ci
 
+      - name: npm audit (diagram renderer)
+        run: cd shared/diagram-renderer && npm audit --omit=dev
+
       - name: npm typecheck (diagram renderer)
         run: cd shared/diagram-renderer && npm run typecheck
 
@@ -244,6 +271,9 @@ jobs:
 
       - name: npm ci (vscode)
         run: cd vscode && npm ci
+
+      - name: npm audit (vscode)
+        run: cd vscode && npm audit --omit=dev
 
       - name: Typecheck extension
         run: cd vscode && npm run typecheck
@@ -286,7 +316,9 @@ jobs:
           cache-dependency-path: vscode/package-lock.json
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}
 
       - name: Prepare SysML stdlib bundle
         run: |
@@ -418,7 +450,9 @@ jobs:
           cache-dependency-path: vscode/package-lock.json
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}
 
       - name: Prepare SysML stdlib bundle
         run: |
@@ -533,8 +567,9 @@ jobs:
           submodules: recursive
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}
           targets: wasm32-wasip2
 
       - name: Cache cargo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ env:
   BINARY_NAME: spec42
   MCP_BINARY_NAME: spec42-mcp
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  # Keep in sync with `channel` in rust-toolchain.toml; bump both deliberately.
+  RUST_TOOLCHAIN_VERSION: "1.97.1"
 
 jobs:
   preflight:
@@ -29,8 +31,9 @@ jobs:
           submodules: recursive
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}
           components: clippy
 
       - name: Cache cargo
@@ -169,8 +172,9 @@ jobs:
           submodules: recursive
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}
           targets: ${{ matrix.target }}
 
       - name: Cache cargo
@@ -352,8 +356,9 @@ jobs:
           ref: ${{ steps.version.outputs.tag || github.ref }}
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}
           targets: wasm32-wasip2
 
       - name: Cache cargo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **Fixed a high-severity DNS rebinding vulnerability in the bundled MCP server** ([RUSTSEC-2026-0189](https://rustsec.org/advisories/RUSTSEC-2026-0189)) — `rmcp` (the crate backing `spec42-mcp`'s Streamable HTTP server transport) was pinned to 0.9.1; upgraded to 1.4+ (resolved to 1.8.0), which also drops the unmaintained `paste` dependency (replaced upstream by `pastey`). The upgrade's API changes (tool/result construction moved to non-exhaustive structs with builder methods) are internal to `crates/server/src/mcp/server.rs`; MCP tool behavior is unchanged (confirmed via the existing `mcp_tools`/`mcp_protocol`/`mcp_binary` integration suites).
+- **Removed the unused `adm-zip` VS Code extension dependency**, which carried a high-severity vulnerability ([GHSA-xcpc-8h2w-3j85](https://github.com/advisories/GHSA-xcpc-8h2w-3j85)). Neither `adm-zip` nor `@types/adm-zip` were referenced anywhere in the extension's source; the scripts that do handle VSIX/zip files already use `@vscode/test-electron`'s downloader and the shell `unzip` command. Also picked up a `brace-expansion` fix via `npm audit fix` (no source changes needed).
+- **Hardened CI**: added a `cargo audit` job (dependency vulnerability scanning), `npm audit --omit=dev` steps for both `shared/diagram-renderer` and `vscode`, and a `cargo doc --no-deps --workspace` step with `RUSTDOCFLAGS=-D warnings` to `ci.yml`'s `rust-core` job (fixed the 14 pre-existing broken/private intra-doc links this surfaced, across `sysml_model`, `workspace`, and `server`). Also pinned `rust-toolchain.toml` and every CI/release Rust-install step to an exact version (`1.97.1`) instead of the floating `stable` channel, so a new stable Rust release adding a default-warn lint can no longer break CI on an unrelated day.
+
 ## [0.49.0] - 2026-07-29
 
 - **Aligns standard-view projection with SysML v2.** `GeneralView`, `BrowserView`, `GridView`,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,11 +307,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -430,9 +428,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -440,11 +438,10 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -454,9 +451,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
@@ -600,12 +597,6 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -927,7 +918,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -1277,9 +1268,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.30.1"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags 2.13.1",
  "cfg-if",
@@ -1372,14 +1363,14 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
+name = "pastey"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "percent-encoding"
@@ -1446,9 +1437,9 @@ dependencies = [
 
 [[package]]
 name = "process-wrap"
-version = "8.2.1"
+version = "9.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ef4f2f0422f23a82ec9f628ea2acd12871c81a9362b02c43c1aa86acfc3ba1"
+checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
 dependencies = [
  "futures",
  "indexmap",
@@ -1705,15 +1696,15 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.9.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaa07b85b779d1e1df52dd79f6c6bffbe005b191f07290136cc42a142da3409a"
+checksum = "1d1f571c72940a19d9532fe52dbea8bc9912bf1d766c2970bb824056b86f3f59"
 dependencies = [
  "async-trait",
  "base64",
  "chrono",
  "futures",
- "paste",
+ "pastey",
  "pin-project-lite",
  "process-wrap",
  "rmcp-macros",
@@ -1729,9 +1720,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.9.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6fa09933cac0d0204c8a5d647f558425538ed6a0134b1ebb1ae4dc00c96db3"
+checksum = "1aad0035b69380782d78ea95b508327e6deaa2235909053e596eea8f27b5e1d5"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2782,37 +2773,23 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.61.3"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
  "windows-collections",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-future",
- "windows-link 0.1.3",
  "windows-numerics",
 ]
 
 [[package]]
 name = "windows-collections"
-version = "0.2.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core 0.61.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -2823,19 +2800,19 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
 name = "windows-future"
-version = "0.2.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
+ "windows-core",
+ "windows-link",
  "windows-threading",
 ]
 
@@ -2863,33 +2840,18 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-numerics"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-core",
+ "windows-link",
 ]
 
 [[package]]
@@ -2898,16 +2860,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -2916,7 +2869,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2943,7 +2896,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2979,11 +2932,11 @@ dependencies = [
 
 [[package]]
 name = "windows-threading"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
 clap = { version = "4", features = ["derive"] }
-rmcp = { version = "0.9", features = ["server"] }
+rmcp = { version = "1.4", features = ["server"] }
 schemars = { version = "1.1", features = ["derive"] }
 petgraph = { version = "0.8", features = ["serde-1"] }
 sysml-v2-parser = { version = "0.51.7", features = ["serde"] }

--- a/crates/server/src/mcp/server.rs
+++ b/crates/server/src/mcp/server.rs
@@ -12,7 +12,7 @@ use crate::mcp::schemas::{
     Spec42CheckParams, Spec42DoctorParams, Spec42ExplainDiagnosticParams, Spec42ModelSummaryParams,
 };
 
-/// Registered MCP tool names (order matches [`build_mcp_tools`]).
+/// Registered MCP tool names (order matches `build_mcp_tools`).
 pub const MCP_TOOL_NAMES: &[&str] = &[
     "spec42_check",
     "spec42_doctor",
@@ -67,70 +67,46 @@ fn build_mcp_tools() -> Vec<rmcp::model::Tool> {
     use rmcp::model::Tool;
 
     vec![
-        Tool {
-            name: MCP_TOOL_NAMES[0].into(),
-            title: Some("Validate SysML / KerML (spec42 check)".into()),
-            description: Some(
-                "Run the same validation pipeline as `spec42 check`. Returns JSON with documents, \
-                diagnostics (code, message, range), summary (error_count, warning_count), and advice. \
-                Set include_semantic_model=true only when you need the full semantic projection; \
-                prefer spec42_model_summary for large workspaces.".into(),
-            ),
-            input_schema: schema_to_map(
+        Tool::new(
+            MCP_TOOL_NAMES[0],
+            "Run the same validation pipeline as `spec42 check`. Returns JSON with documents, \
+            diagnostics (code, message, range), summary (error_count, warning_count), and advice. \
+            Set include_semantic_model=true only when you need the full semantic projection; \
+            prefer spec42_model_summary for large workspaces.",
+            schema_to_map(
                 serde_json::to_value(schemars::schema_for!(Spec42CheckParams)).unwrap_or_default(),
             ),
-            output_schema: None,
-            annotations: None,
-            icons: None,
-            meta: None,
-        },
-        Tool {
-            name: MCP_TOOL_NAMES[1].into(),
-            title: Some("Spec42 environment doctor".into()),
-            description: Some(
-                "Report standard library installation, config/data dirs, library paths, and Sysand \
-                detection (same as `spec42 doctor`). Run before blaming unresolved imports on model text.".into(),
-            ),
-            input_schema: schema_to_map(
+        )
+        .with_title("Validate SysML / KerML (spec42 check)"),
+        Tool::new(
+            MCP_TOOL_NAMES[1],
+            "Report standard library installation, config/data dirs, library paths, and Sysand \
+            detection (same as `spec42 doctor`). Run before blaming unresolved imports on model text.",
+            schema_to_map(
                 serde_json::to_value(schemars::schema_for!(Spec42DoctorParams)).unwrap_or_default(),
             ),
-            output_schema: None,
-            annotations: None,
-            icons: None,
-            meta: None,
-        },
-        Tool {
-            name: MCP_TOOL_NAMES[2].into(),
-            title: Some("Compact semantic model summary".into()),
-            description: Some(
-                "Validate the path and return a capped semantic graph: nodes (qualified names, kinds) \
-                and relationships filtered to typing, connection, and reference. Use max_nodes to limit payload size.".into(),
-            ),
-            input_schema: schema_to_map(
+        )
+        .with_title("Spec42 environment doctor"),
+        Tool::new(
+            MCP_TOOL_NAMES[2],
+            "Validate the path and return a capped semantic graph: nodes (qualified names, kinds) \
+            and relationships filtered to typing, connection, and reference. Use max_nodes to limit payload size.",
+            schema_to_map(
                 serde_json::to_value(schemars::schema_for!(Spec42ModelSummaryParams))
                     .unwrap_or_default(),
             ),
-            output_schema: None,
-            annotations: None,
-            icons: None,
-            meta: None,
-        },
-        Tool {
-            name: MCP_TOOL_NAMES[3].into(),
-            title: Some("Explain a diagnostic code".into()),
-            description: Some(
-                "Deterministic catalog entry for a diagnostic code (severity, meaning, typical fix, \
-                editor quick-fix hints). Optionally pass path and line to list matching instances from spec42_check.".into(),
-            ),
-            input_schema: schema_to_map(
+        )
+        .with_title("Compact semantic model summary"),
+        Tool::new(
+            MCP_TOOL_NAMES[3],
+            "Deterministic catalog entry for a diagnostic code (severity, meaning, typical fix, \
+            editor quick-fix hints). Optionally pass path and line to list matching instances from spec42_check.",
+            schema_to_map(
                 serde_json::to_value(schemars::schema_for!(Spec42ExplainDiagnosticParams))
                     .unwrap_or_default(),
             ),
-            output_schema: None,
-            annotations: None,
-            icons: None,
-            meta: None,
-        },
+        )
+        .with_title("Explain a diagnostic code"),
     ]
 }
 
@@ -157,38 +133,30 @@ pub fn execute_tool(
 
 impl ServerHandler for Spec42McpServer {
     fn get_info(&self) -> InitializeResult {
-        use rmcp::model::ProtocolVersion;
-        InitializeResult {
-            protocol_version: ProtocolVersion::V_2024_11_05,
-            capabilities: rmcp::model::ServerCapabilities {
-                tools: Some(rmcp::model::ToolsCapability { list_changed: None }),
-                ..Default::default()
-            },
-            server_info: rmcp::model::Implementation {
-                name: "spec42-mcp".into(),
-                version: env!("CARGO_PKG_VERSION").into(),
-                title: Some("Spec42 MCP".into()),
-                website_url: Some("https://github.com/elan8/spec42".into()),
-                icons: None,
-            },
-            instructions: Some(MCP_INSTRUCTIONS.into()),
-        }
+        use rmcp::model::{Implementation, ProtocolVersion, ServerCapabilities};
+        InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
+            .with_protocol_version(ProtocolVersion::V_2024_11_05)
+            .with_server_info(
+                Implementation::new("spec42-mcp", env!("CARGO_PKG_VERSION"))
+                    .with_title("Spec42 MCP")
+                    .with_website_url("https://github.com/elan8/spec42"),
+            )
+            .with_instructions(MCP_INSTRUCTIONS)
     }
 
     async fn list_tools(
         &self,
-        _paginated: Option<rmcp::model::PaginatedRequestParam>,
+        _paginated: Option<rmcp::model::PaginatedRequestParams>,
         _ctx: RequestContext<RoleServer>,
     ) -> Result<rmcp::model::ListToolsResult, rmcp::ErrorData> {
-        Ok(rmcp::model::ListToolsResult {
-            tools: build_mcp_tools(),
-            next_cursor: None,
-        })
+        Ok(rmcp::model::ListToolsResult::with_all_items(
+            build_mcp_tools(),
+        ))
     }
 
     async fn call_tool(
         &self,
-        params: rmcp::model::CallToolRequestParam,
+        params: rmcp::model::CallToolRequestParams,
         _ctx: RequestContext<RoleServer>,
     ) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
         let arguments = Value::Object(params.arguments.unwrap_or_default());
@@ -197,19 +165,7 @@ impl ServerHandler for Spec42McpServer {
 }
 
 fn tool_success(content: Value) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
-    let content_str = serde_json::to_string(&content).unwrap_or_default();
-    Ok(rmcp::model::CallToolResult {
-        content: vec![rmcp::model::Annotated {
-            raw: rmcp::model::RawContent::Text(rmcp::model::RawTextContent {
-                text: content_str,
-                meta: None,
-            }),
-            annotations: None,
-        }],
-        is_error: Some(false),
-        meta: None,
-        structured_content: Some(content),
-    })
+    Ok(rmcp::model::CallToolResult::structured(content))
 }
 
 fn tool_error(name: &str, e: String) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
@@ -236,21 +192,7 @@ fn tool_error(name: &str, e: String) -> Result<rmcp::model::CallToolResult, rmcp
             "example_retry": example_retry,
         }
     });
-    let error_str = serde_json::to_string(&error_content).unwrap_or_else(|_| {
-        format!("{{\"error\":{{\"code\":{error_code},\"message\":\"{name} failed\"}}}}")
-    });
-    Ok(rmcp::model::CallToolResult {
-        content: vec![rmcp::model::Annotated {
-            raw: rmcp::model::RawContent::Text(rmcp::model::RawTextContent {
-                text: error_str,
-                meta: None,
-            }),
-            annotations: None,
-        }],
-        is_error: Some(true),
-        meta: None,
-        structured_content: Some(error_content),
-    })
+    Ok(rmcp::model::CallToolResult::structured_error(error_content))
 }
 
 pub async fn run() -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/server/tests/mcp_binary.rs
+++ b/crates/server/tests/mcp_binary.rs
@@ -3,7 +3,7 @@
 mod common;
 
 use common::with_isolated_data_dir_async;
-use rmcp::model::CallToolRequestParam;
+use rmcp::model::CallToolRequestParams;
 use rmcp::transport::TokioChildProcess;
 use rmcp::ServiceExt;
 
@@ -25,10 +25,9 @@ async fn spec42_mcp_binary_lists_tools_and_doctor() -> anyhow::Result<()> {
         }
 
         let doctor = client
-            .call_tool(CallToolRequestParam {
-                name: "spec42_doctor".into(),
-                arguments: Some(serde_json::Map::new()),
-            })
+            .call_tool(
+                CallToolRequestParams::new("spec42_doctor").with_arguments(serde_json::Map::new()),
+            )
             .await?;
         assert_ne!(doctor.is_error, Some(true));
         let structured = doctor.structured_content.expect("doctor json");

--- a/crates/server/tests/mcp_protocol.rs
+++ b/crates/server/tests/mcp_protocol.rs
@@ -5,7 +5,7 @@ mod common;
 use std::path::PathBuf;
 
 use common::with_isolated_data_dir_async;
-use rmcp::model::{CallToolRequestParam, ClientInfo};
+use rmcp::model::{CallToolRequestParams, ClientInfo};
 use rmcp::{ClientHandler, ServiceExt};
 use serde_json::json;
 use spec42::mcp::server::{Spec42McpServer, MCP_TOOL_NAMES};
@@ -67,15 +67,14 @@ async fn mcp_protocol_call_spec42_check() -> anyhow::Result<()> {
 
         let client = TestMcpClient.serve(client_transport).await?;
         let result = client
-            .call_tool(CallToolRequestParam {
-                name: "spec42_check".into(),
-                arguments: Some(
+            .call_tool(
+                CallToolRequestParams::new("spec42_check").with_arguments(
                     json!({ "path": path.display().to_string() })
                         .as_object()
                         .unwrap()
                         .clone(),
                 ),
-            })
+            )
             .await?;
 
         assert_ne!(result.is_error, Some(true));
@@ -104,12 +103,7 @@ async fn mcp_protocol_unknown_tool_returns_error_result() -> anyhow::Result<()> 
         });
 
         let client = TestMcpClient.serve(client_transport).await?;
-        let result = client
-            .call_tool(CallToolRequestParam {
-                name: "nope".into(),
-                arguments: None,
-            })
-            .await?;
+        let result = client.call_tool(CallToolRequestParams::new("nope")).await?;
 
         assert_eq!(result.is_error, Some(true));
         let structured = result.structured_content.expect("structured error content");

--- a/crates/sysml_model/src/semantic/ast_util.rs
+++ b/crates/sysml_model/src/semantic/ast_util.rs
@@ -522,7 +522,7 @@ impl ExpressionAlgebra for DeclaredExpressionAlgebra {
 /// uses the debug renderer; structural children and named arguments remain
 /// explicit for later addressable projection.
 ///
-/// Iterative, not recursive: see [`crate::semantic::expression_fold`] for why.
+/// Iterative, not recursive: see the `semantic::expression_fold` module doc for why.
 pub fn declared_expression(node: &Node<Expression>) -> DeclaredExpression {
     fold_expression(node, &mut DeclaredExpressionAlgebra)
 }

--- a/crates/sysml_model/src/semantic/component_view.rs
+++ b/crates/sysml_model/src/semantic/component_view.rs
@@ -198,7 +198,7 @@ pub fn expand_part_usage(
 
 /// Resolves the canonical type/specialization target for a usage-like node.
 ///
-/// Unlike [`first_typed_definition_with_shape`], this does not require the
+/// Unlike `first_typed_definition_with_shape`, this does not require the
 /// target to have materialized shape or be part-like: `typedBy` should point
 /// at whatever the usage is typed by (a `part def`, `port def`, `item def`,
 /// `attribute def`, `action def`, ...) even if that definition has no members.

--- a/crates/sysml_model/src/semantic/explicit_views.rs
+++ b/crates/sysml_model/src/semantic/explicit_views.rs
@@ -72,7 +72,8 @@ pub struct EvaluatedView {
 
 /// Build a catalog of view definitions and usages from parsed workspace documents.
 ///
-/// Callers (for example the LSP server) typically derive [`WorkspaceParsedDocument`] values
+/// Callers (for example the LSP server) typically derive
+/// [`WorkspaceParsedDocument`](crate::semantic::workspace_graph::WorkspaceParsedDocument) values
 /// from their on-disk index; the graph-first workspace builder passes the documents returned
 /// alongside [`crate::semantic::graph::SemanticGraph`].
 pub fn build_view_catalog(

--- a/crates/sysml_model/src/semantic/graph.rs
+++ b/crates/sysml_model/src/semantic/graph.rs
@@ -48,12 +48,12 @@ struct ShapeCache {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SemanticGraphData {
     pub graph: StableGraph<SemanticNode, SemanticEdge, Directed>,
-    /// Rebuilt after deserialization via [`rebuild_derived_indexes`].
+    /// Rebuilt after deserialization via [`SemanticGraphData::rebuild_derived_indexes`].
     #[serde(skip)]
     pub node_index_by_id: HashMap<NodeId, NodeIndex>,
     pub nodes_by_uri: HashMap<Url, Vec<NodeId>>,
     pub node_ids_by_qualified_name: HashMap<String, Vec<NodeId>>,
-    /// Rebuilt after deserialization via [`rebuild_derived_indexes`].
+    /// Rebuilt after deserialization via [`SemanticGraphData::rebuild_derived_indexes`].
     #[serde(skip)]
     pub children_by_parent_id: HashMap<NodeId, Vec<NodeId>>,
     pub pending_expression_relationships: Vec<PendingExpressionRelationship>,
@@ -71,19 +71,19 @@ pub struct SemanticGraphData {
     /// of another document's resolution outcome. Deliberately NOT a cache of resolution
     /// results — a reference that temporarily fails to resolve (e.g. its target is renamed
     /// away then back) must not cause this to go stale, since nothing would ever trigger
-    /// re-checking it. Rebuilt after deserialization via [`rebuild_derived_indexes`].
+    /// re-checking it. Rebuilt after deserialization via [`SemanticGraphData::rebuild_derived_indexes`].
     #[serde(skip)]
     pub document_dependency_targets: HashMap<Url, HashSet<Url>>,
     /// Reverse of `document_dependency_targets`: for each URI, the other URIs that statically
     /// depend on it. This is `refresh_relationship_frontier`'s frontier source — every URI
     /// that might need its relationships re-resolved after `changed_uri` is edited. Rebuilt
-    /// after deserialization via [`rebuild_derived_indexes`].
+    /// after deserialization via [`SemanticGraphData::rebuild_derived_indexes`].
     #[serde(skip)]
     pub document_dependents: HashMap<Url, HashSet<Url>>,
     /// The exact (src, tgt, kind) triples `add_cross_document_edges_for_uri` last added for a
     /// given source URI. Lets a re-resolve for that URI cleanly remove its own prior
     /// cross-document edges before adding fresh ones, without touching edges owned by other
-    /// passes. Rebuilt after deserialization via [`rebuild_derived_indexes`].
+    /// passes. Rebuilt after deserialization via [`SemanticGraphData::rebuild_derived_indexes`].
     #[serde(skip)]
     pub cross_document_edges_by_source_uri: HashMap<Url, Vec<(NodeId, NodeId, RelationshipKind)>>,
 }

--- a/crates/sysml_model/src/semantic/visualization/projection.rs
+++ b/crates/sysml_model/src/semantic/visualization/projection.rs
@@ -235,7 +235,7 @@ pub fn top_level_package_for_node_id(node_id: &str) -> String {
 
 /// Filters activity diagrams by cross-referencing an already-projected `graph`'s action-like
 /// nodes, keyed by `(name, top_level_package)` — deliberately **not** the same mechanism as
-/// [`crate::semantic::exposed_ids::filter_by_exposed_ids`] (used by
+/// `exposed_ids::filter_by_exposed_ids` (used by
 /// `filter_sequence_diagrams_by_exposed_ids`/`filter_state_machines_by_exposed_ids`), which
 /// matches diagram ids directly against a raw `exposed_ids` set independent of any graph
 /// projection. Investigated during the view-pipeline refactor and confirmed intentional, not

--- a/crates/workspace/src/incremental.rs
+++ b/crates/workspace/src/incremental.rs
@@ -149,7 +149,7 @@ impl IncrementalWorkspace {
     /// Full load from documents this engine has already parsed — e.g. a caller with its own
     /// pre-parsed document index (`lsp_server`'s `IndexEntry.parsed`) that would otherwise
     /// have to throw that work away to call [`Self::load`]. Delegates to
-    /// [`link_parsed_documents_parallel`] — the merge/link half of
+    /// [`sysml_model::link_parsed_documents_parallel`] — the merge/link half of
     /// [`build_and_link_graph_parallel`] with the parse step already done by the caller.
     pub fn load_parsed(
         &mut self,
@@ -334,7 +334,7 @@ impl IncrementalWorkspace {
 /// graph/documents, without building a [`crate::snapshot::HostWorkspaceSnapshot`].
 ///
 /// A thin, same-crate call into `snapshot::facts::collect_host_validation_report` — the exact
-/// function [`crate::snapshot::build::build_workspace_snapshot`] already uses internally.
+/// function `snapshot::build::build_workspace_snapshot` already uses internally.
 /// Exists so embedders that hold an [`IncrementalWorkspace`] directly (rather than going
 /// through the `snapshot` pipeline) can still get diagnostics, without paying for the rest of
 /// a snapshot's eager derived fields (`language_workspace`/`render_snapshot`/

--- a/crates/workspace/src/parse_cache.rs
+++ b/crates/workspace/src/parse_cache.rs
@@ -96,7 +96,7 @@ pub fn store(cache_dir: &Path, hash: &[u8; 32], root: &RootNamespace) {
 }
 
 /// Delete cache entries whose `ast_version` header does not match the current
-/// binary's [`AST_VERSION`]. Call once at startup on a background thread.
+/// binary's [`sysml_v2_parser::PARSE_AST_VERSION`]. Call once at startup on a background thread.
 /// Non-fatal — errors are silently ignored.
 pub fn evict_stale_entries(cache_dir: &Path) {
     let Ok(entries) = std::fs::read_dir(cache_dir) else {

--- a/crates/workspace/src/snapshot/discovery.rs
+++ b/crates/workspace/src/snapshot/discovery.rs
@@ -66,7 +66,7 @@ pub fn discover_target_files(targets: &[PathBuf]) -> WorkspaceResult<Vec<PathBuf
 /// Public so embedders holding an [`crate::IncrementalWorkspace`] directly (not going through
 /// the `snapshot` build pipeline) can compute `library_urls` for
 /// [`crate::validate_workspace`] with the same normalization
-/// [`super::build::build_workspace_snapshot`] applies — see `SPEC42-ISSUES.md` in downstream
+/// `snapshot::build::build_workspace_snapshot` applies — see `SPEC42-ISSUES.md` in downstream
 /// consumers for what silently diverging normalization once broke.
 pub fn path_to_file_url(path: &Path) -> WorkspaceResult<Url> {
     let absolute = if path.is_absolute() {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,8 @@
 [toolchain]
-channel = "stable"
+# Exact version, not a floating "stable" channel: spec42 isn't published to crates.io, so
+# there's no downstream MSRV promise to keep -- this pin exists purely so CI (and local
+# `cargo` invocations, via rustup's toolchain-file auto-detection) can't be broken by a new
+# stable Rust release adding a default-warn lint on an unrelated day. Keep in sync with
+# RUST_TOOLCHAIN_VERSION in .github/workflows/ci.yml and release.yml; bump both deliberately.
+channel = "1.97.1"
 components = ["clippy", "rustfmt"]

--- a/vscode/package-lock.json
+++ b/vscode/package-lock.json
@@ -9,14 +9,12 @@
       "version": "0.49.0",
       "license": "MIT",
       "dependencies": {
-        "adm-zip": "^0.5.16",
         "d3": "^7.9.0",
         "elkjs": "^0.11.1",
         "vscode-languageclient": "^9.0.0",
         "vscode-languageserver-protocol": "^3.17.0"
       },
       "devDependencies": {
-        "@types/adm-zip": "^0.5.8",
         "@types/d3": "^7.4.3",
         "@types/mocha": "^10.0.0",
         "@types/node": "^22.0.0",
@@ -144,9 +142,9 @@
       }
     },
     "node_modules/@azure/identity": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.13.0.tgz",
-      "integrity": "sha512-uWC0fssc+hs1TGGVkkghiaFkkS7NkTxfnCH+Hdg+yTehTpMcehpok4PgUKKdyCH+9ldu6FhiHRv84Ntqj1vVcw==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.13.1.tgz",
+      "integrity": "sha512-5C/2WD5Vb1lHnZS16dNQRPMjN6oV/Upba+C9nBIs15PmOi6A3ZGs4Lr2u60zw4S04gi+u3cEXiqTVP7M4Pz3kw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -157,8 +155,8 @@
         "@azure/core-tracing": "^1.0.0",
         "@azure/core-util": "^1.11.0",
         "@azure/logger": "^1.0.0",
-        "@azure/msal-browser": "^4.2.0",
-        "@azure/msal-node": "^3.5.0",
+        "@azure/msal-browser": "^5.5.0",
+        "@azure/msal-node": "^5.1.0",
         "open": "^10.1.0",
         "tslib": "^2.2.0"
       },
@@ -181,22 +179,22 @@
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "4.29.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-4.29.0.tgz",
-      "integrity": "sha512-/f3eHkSNUTl6DLQHm+bKecjBKcRQxbd/XLx8lvSYp8Nl/HRyPuIPOijt9Dt0sH50/SxOwQ62RnFCmFlGK+bR/w==",
+      "version": "5.17.3",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.17.3.tgz",
+      "integrity": "sha512-qMabD7Xrm/UgRhs+/IVyCTZRjUl8Qb+uGsRrCkaKNWsiTwRaeyStJbChE7/ySNTNYtiWo7khfF7vUDd0wGMnLw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "15.15.0"
+        "@azure/msal-common": "16.11.3"
       },
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-common": {
-      "version": "15.15.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.15.0.tgz",
-      "integrity": "sha512-/n+bN0AKlVa+AOcETkJSKj38+bvFs78BaP4rNtv3MJCmPH0YrHiskMRe74OhyZ5DZjGISlFyxqvf9/4QVEi2tw==",
+      "version": "16.11.3",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.11.3.tgz",
+      "integrity": "sha512-VeXOW+t3Rdd9XGX6lVyIg3DhtjMR1JD8ARKcsnGbJFUWwAmF3sHL7GwZc/ZjEUfHESResAonETRYCuG06OBT7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -204,18 +202,17 @@
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "3.8.8",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-3.8.8.tgz",
-      "integrity": "sha512-+f1VrJH1iI517t4zgmuhqORja0bL6LDQXfBqkjuMmfTYXTQQnh1EvwwxO3UbKLT05N0obF72SRHFrC1RBDv5Gg==",
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.4.3.tgz",
+      "integrity": "sha512-tumCMmzrRhKmTbYQg/7OlfbrIKcKaf8Ed0Fw3suUpRT3owFYljznVgxcfHe8RycQXY9uyROGiLD1GjhpF45AwA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "15.15.0",
-        "jsonwebtoken": "^9.0.0",
-        "uuid": "^8.3.0"
+        "@azure/msal-common": "16.11.3",
+        "jsonwebtoken": "^9.0.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=20"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1073,16 +1070,6 @@
         "@textlint/ast-node-types": "15.5.2"
       }
     },
-    "node_modules/@types/adm-zip": {
-      "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.8.tgz",
-      "integrity": "sha512-RVVH7QvZYbN+ihqZ4kX/dMiowf6o+Jk1fNwiSdx0NahBJLU787zkULhGhJM8mf/obmLGmgdMM0bXsQTmyfbR7Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/d3": {
       "version": "7.4.3",
       "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
@@ -1701,9 +1688,9 @@
       }
     },
     "node_modules/@vscode/vsce/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1747,16 +1734,16 @@
       }
     },
     "node_modules/@vscode/vsce/node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@vscode/vsce/node_modules/glob/node_modules/minimatch": {
@@ -1829,15 +1816,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/adm-zip": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
-      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0"
       }
     },
     "node_modules/agent-base": {
@@ -2062,9 +2040,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -3439,9 +3417,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -3533,17 +3511,17 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -3806,9 +3784,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4283,10 +4261,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -4428,10 +4416,20 @@
       }
     },
     "node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
@@ -4454,9 +4452,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -4557,15 +4555,25 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
-      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
+      "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
-        "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
+        "entities": "^4.5.0",
+        "linkify-it": "^5.0.2",
         "mdurl": "^2.0.0",
         "punycode.js": "^2.3.1",
         "uc.micro": "^2.1.0"
@@ -4720,9 +4728,9 @@
       "optional": true
     },
     "node_modules/mocha": {
-      "version": "11.7.5",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.5.tgz",
-      "integrity": "sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==",
+      "version": "11.8.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.8.0.tgz",
+      "integrity": "sha512-VyCeUdGN3A9lmCTTgG4yuvY9ixxaDk+xt2R/7/+1AP6EqNG+G9OKkzBwhVtVYoNX8YsxNSgAl8mOv3IAeOpFbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5315,9 +5323,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5396,13 +5404,14 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -5753,15 +5762,15 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -5773,14 +5782,14 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6307,9 +6316,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6376,9 +6385,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6483,9 +6492,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.22.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
-      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6535,16 +6544,6 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -781,7 +781,7 @@
         "spec42.debug": {
           "type": "boolean",
           "default": false,
-          "description": "Enable debug logging to the SysML output channel (View \u2192 Output \u2192 SysML)."
+          "description": "Enable debug logging to the SysML output channel (View → Output → SysML)."
         },
         "spec42.logging.verbose": {
           "type": "boolean",
@@ -843,7 +843,6 @@
     "package": "vsce package"
   },
   "devDependencies": {
-    "@types/adm-zip": "^0.5.8",
     "@types/d3": "^7.4.3",
     "@types/mocha": "^10.0.0",
     "@types/node": "^22.0.0",
@@ -856,7 +855,6 @@
     "typescript": "~5.6.0"
   },
   "dependencies": {
-    "adm-zip": "^0.5.16",
     "d3": "^7.9.0",
     "elkjs": "^0.11.1",
     "vscode-languageclient": "^9.0.0",


### PR DESCRIPTION
## Summary

Follows the same audit already done for [sysml-v2-parser#32](https://github.com/elan8/sysml-v2-parser/issues/32), applied to this repo's items:

- **`cargo audit` job added.** Found one real, high-severity vulnerability: [RUSTSEC-2026-0189](https://rustsec.org/advisories/RUSTSEC-2026-0189), a DNS rebinding hole in `rmcp` 0.9.1's Streamable HTTP server transport — `rmcp` is `spec42-mcp`'s own dependency, not a theoretical transitive concern. Upgraded to `rmcp` 1.4+ (resolved to 1.8.0, `>=1.4.0` per the advisory's Solution line), which also drops the unmaintained `paste` dependency (replaced upstream by `pastey`). rmcp 1.x moved several model types (`Tool`, `InitializeResult`, `ServerCapabilities`, `CallToolResult`, `CallToolRequestParams`, ...) to `#[non_exhaustive]` with builder methods; `crates/server/src/mcp/server.rs` and the two integration test files that construct `CallToolRequestParam` are updated accordingly. Behavior is unchanged — confirmed via the existing `mcp_tools`/`mcp_protocol`/`mcp_binary` integration suites, all passing. The remaining `bincode` "unmaintained" advisory has no fixed version yet and isn't blocking (`cargo audit` only fails on actual vulnerabilities, not unmaintained-warnings), so no `--ignore` was needed.
- **`npm audit --omit=dev` added** for both `shared/diagram-renderer` (clean) and `vscode`. `vscode` had two real high-severity findings:
  - `brace-expansion` — fixed via a plain `npm audit fix` (non-breaking).
  - `adm-zip` — the issue flagged this as needing `--force` (a breaking change). Grepping the extension's source turned up **zero usages** of `adm-zip`/`AdmZip` anywhere; the scripts that do handle VSIX/zip files already use `@vscode/test-electron`'s `downloadAndUnzipVSCode` and the shell `unzip` command. Removed `adm-zip`/`@types/adm-zip` entirely instead of force-upgrading — same fix, no breaking-change risk. `npm audit --omit=dev` now reports 0 vulnerabilities for both packages.
- **`cargo doc --no-deps --workspace` gate added** with `RUSTDOCFLAGS=-D warnings`. Fixed the 14 pre-existing warnings this surfaced (9 in `sysml_model`, 4 in `workspace`, 1 in `server`) — all broken or private intra-doc links (stale renamed items, links to `pub(crate)` items from public docs, an unqualified path not in scope at that call site). De-linked references to genuinely private items to plain code text; fixed paths for the ones pointing at real, reachable items.
- **Toolchain pinning** (the issue framed this as a policy decision — confirmed with the user before proceeding): pinned `rust-toolchain.toml`'s `channel` to the exact `1.97.1` instead of the floating `stable`, and updated every `dtolnay/rust-toolchain@stable` step in `ci.yml`/`release.yml` (8 total) to `@master` + an explicit `toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}` input, with that version defined once per workflow's `env:` block as the single source of truth. `nightly.yml`'s scheduled, `continue-on-error: true`, explicitly-"(informational)" canary job is deliberately left floating on `stable` — that's the right place for early warning of an upcoming stable-Rust break, while the PR-blocking gates stay reproducible.

## Test plan

- [x] `cargo test --workspace -- --skip export_interconnection_scene_typescript_bindings` — all passing (that skip is a pre-existing, unrelated CRLF/LF mismatch in a generated TypeScript binding file, confirmed present on unmodified `main` too)
- [x] `cargo test -p server --test mcp_tools --test cli_ai_tools --test mcp_protocol --test mcp_binary -- --include-ignored` — all passing after the rmcp 1.x migration
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace` — clean (was 14 warnings)
- [x] `cargo audit` — clean (was 1 high-severity vulnerability + 2 unmaintained warnings; now 1 unmaintained warning, non-blocking)
- [x] `npm audit --omit=dev` in both `shared/diagram-renderer` and `vscode` — 0 vulnerabilities (was 0 and 2-high respectively)
- [x] Both modified workflow YAML files parse correctly (validated with `js-yaml`) and list all expected jobs including the new `audit` job

🤖 Generated with [Claude Code](https://claude.com/claude-code)