### PR TITLE
Support numeric analysis return attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **Supports typed numeric analysis results and objective evaluation.** Analysis `return attribute`
+  declarations are materialized with their type and expression, inherited by typed analysis usages,
+  evaluated as numeric values rather than Boolean verdicts, and checked against typed objective
+  requirement constraints. Existing `return ref` and verification verdict behavior is preserved.
+
 - **Fixed a high-severity DNS rebinding vulnerability in the bundled MCP server** ([RUSTSEC-2026-0189](https://rustsec.org/advisories/RUSTSEC-2026-0189)) — `rmcp` (the crate backing `spec42-mcp`'s Streamable HTTP server transport) was pinned to 0.9.1; upgraded to 1.4+ (resolved to 1.8.0), which also drops the unmaintained `paste` dependency (replaced upstream by `pastey`). The upgrade's API changes (tool/result construction moved to non-exhaustive structs with builder methods) are internal to `crates/server/src/mcp/server.rs`; MCP tool behavior is unchanged (confirmed via the existing `mcp_tools`/`mcp_protocol`/`mcp_binary` integration suites).
 - **Removed the unused `adm-zip` VS Code extension dependency**, which carried a high-severity vulnerability ([GHSA-xcpc-8h2w-3j85](https://github.com/advisories/GHSA-xcpc-8h2w-3j85)). Neither `adm-zip` nor `@types/adm-zip` were referenced anywhere in the extension's source; the scripts that do handle VSIX/zip files already use `@vscode/test-electron`'s downloader and the shell `unzip` command. Also picked up a `brace-expansion` fix via `npm audit fix` (no source changes needed).
 - **Hardened CI**: added a `cargo audit` job (dependency vulnerability scanning), `npm audit --omit=dev` steps for both `shared/diagram-renderer` and `vscode`, and a `cargo doc --no-deps --workspace` step with `RUSTDOCFLAGS=-D warnings` to `ci.yml`'s `rust-core` job (fixed the 14 pre-existing broken/private intra-doc links this surfaced, across `sysml_model`, `workspace`, and `server`). Also pinned `rust-toolchain.toml` and every CI/release Rust-install step to an exact version (`1.97.1`) instead of the floating `stable` channel, so a new stable Rust release adding a default-warn lint can no longer break CI on an unrelated day.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2148,9 +2148,9 @@ dependencies = [
 
 [[package]]
 name = "sysml-v2-parser"
-version = "0.51.7"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c9fb64c62ea204fa30e6daf03126039cab3fb56c140a9db1eeaf5fd0c6e6225"
+checksum = "7151ec3dde21566673afeebb0d7fe29524d5bc77538ae1897e020a3796400f4e"
 dependencies = [
  "log",
  "nom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,5 +31,5 @@ clap = { version = "4", features = ["derive"] }
 rmcp = { version = "1.4", features = ["server"] }
 schemars = { version = "1.1", features = ["derive"] }
 petgraph = { version = "0.8", features = ["serde-1"] }
-sysml-v2-parser = { version = "0.51.7", features = ["serde"] }
+sysml-v2-parser = { version = "0.53.0", features = ["serde"] }
 ts-rs = { version = "11", features = ["serde-compat", "serde-json-impl"] }

--- a/crates/lsp_server/tests/integration/model.rs
+++ b/crates/lsp_server/tests/integration/model.rs
@@ -2008,7 +2008,7 @@ fn lsp_sysml_model_graph_includes_verification_semantics() {
 }
 
 #[test]
-fn lsp_sysml_model_graph_includes_analysis_objective_binding_to_result() {
+fn lsp_sysml_model_graph_includes_typed_numeric_analysis_result() {
     let mut child = spawn_server();
     let mut stdin = child.stdin.take().expect("stdin");
     let mut stdout = child.stdout.take().expect("stdout");
@@ -2016,13 +2016,17 @@ fn lsp_sysml_model_graph_includes_analysis_objective_binding_to_result() {
     let uri = "file:///analysis_graph_test.sysml";
     let content = r#"
         package V {
-            part def System;
-            analysis def AnalyzeStartup {
-                subject testSystem : System;
-                return ref analysisResult { return 1; }
-                objective startupObjective {
-                    doc /* Analyze startup behavior. */
-                }
+            attribute def PowerLevel :> Real;
+            requirement def MinimumPower {
+                subject result : PowerLevel;
+                attribute minimum : PowerLevel = -6.0;
+                require constraint { result >= minimum }
+            }
+            analysis AnalyzePower {
+                attribute inputPower : PowerLevel = 3.0;
+                attribute loss : Real = 7.5;
+                return attribute outputPower : PowerLevel = inputPower - loss;
+                objective powerObjective : MinimumPower;
             }
         }
     "#;
@@ -2071,16 +2075,24 @@ fn lsp_sysml_model_graph_includes_analysis_objective_binding_to_result() {
     let nodes = model_json["result"]["graph"]["nodes"]
         .as_array()
         .expect("graph nodes array");
-
     assert!(
         nodes.iter().any(|node| {
             node["type"].as_str() == Some("objective")
                 && node["attributes"]["objectiveBindingKind"].as_str() == Some("analysis_result")
                 && node["attributes"]["objectiveBoundTo"]
                     .as_str()
-                    .is_some_and(|bound_to| bound_to.ends_with("analysisResult"))
+                    .is_some_and(|bound_to| bound_to.ends_with("outputPower"))
         }),
         "expected analysis objective binding to analysis result in graph output"
+    );
+    assert!(
+        nodes.iter().any(|node| {
+            node["type"].as_str() == Some("analysis result")
+                && node["name"].as_str() == Some("outputPower")
+                && node["attributes"]["returnType"].as_str() == Some("PowerLevel")
+                && node["attributes"]["value"].as_str() == Some("(inputPower - loss)")
+        }),
+        "expected typed numeric analysis result expression in graph output: {nodes:#?}"
     );
 
     let _ = child.kill();

--- a/crates/server/src/mcp/diagnostic_catalog.rs
+++ b/crates/server/src/mcp/diagnostic_catalog.rs
@@ -623,7 +623,7 @@ const CATALOG: &[DiagnosticCatalogEntry] = &[
         code: "case_objective_binding_cardinality",
         severity: "warning",
         meaning: "Case objectives expect a single subject or analysis result but the case declares the wrong count.",
-        typical_fix: "Declare exactly one subject or return ref matching the objective binding kind.",
+        typical_fix: "Declare exactly one subject or returned analysis result matching the objective binding kind.",
         editor_quick_fixes: None,
     },
     DiagnosticCatalogEntry {

--- a/crates/server/tests/mcp_tools.rs
+++ b/crates/server/tests/mcp_tools.rs
@@ -20,6 +20,25 @@ fn invalid_fixture_path() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/mcp_invalid.sysml")
 }
 
+const NUMERIC_ANALYSIS_FIXTURE: &str = r#"
+package AnalysisDemo {
+    attribute def PowerLevel :> Real;
+
+    requirement def MinimumPower {
+        subject result : PowerLevel;
+        attribute minimum : PowerLevel = -6.0;
+        require constraint { result >= minimum }
+    }
+
+    analysis AnalyzePower {
+        attribute inputPower : PowerLevel = 3.0;
+        attribute loss : Real = 7.5;
+        return attribute outputPower : PowerLevel = inputPower - loss;
+        objective powerObjective : MinimumPower;
+    }
+}
+"#;
+
 #[test]
 #[ignore = "agent/API/MCP integration; run: cargo test -p spec42 -- --include-ignored"]
 fn mcp_tool_names_match_server_registration() {
@@ -150,6 +169,57 @@ fn mcp_model_summary_respects_max_nodes() {
             .and_then(|v| v.as_array())
             .expect("nodes");
         assert_eq!(nodes.len(), 1);
+    });
+}
+
+#[test]
+#[ignore = "agent/API/MCP integration; run: cargo test -p spec42 -- --include-ignored"]
+fn mcp_model_summary_includes_evaluated_numeric_analysis_result() {
+    with_isolated_data_dir(|| {
+        let model_dir = tempfile::TempDir::new().expect("numeric analysis temp dir");
+        let model_path = model_dir.path().join("NumericAnalysis.sysml");
+        std::fs::write(&model_path, NUMERIC_ANALYSIS_FIXTURE)
+            .expect("write numeric analysis fixture");
+
+        let value = handle_spec42_model_summary(json!({
+            "path": model_path.display().to_string(),
+            "max_nodes": 50,
+        }))
+        .expect("numeric analysis model summary");
+        let nodes = value["nodes"].as_array().expect("summary nodes");
+
+        let result = nodes
+            .iter()
+            .find(|node| {
+                node["element_kind"].as_str() == Some("analysis result")
+                    && node["name"].as_str() == Some("outputPower")
+            })
+            .expect("numeric analysis result node");
+        assert_eq!(
+            result["attributes"]["returnType"].as_str(),
+            Some("PowerLevel")
+        );
+        assert_eq!(result["attributes"]["evaluatedValue"].as_f64(), Some(-4.5));
+
+        let analysis = nodes
+            .iter()
+            .find(|node| {
+                node["element_kind"].as_str() == Some("analysis")
+                    && node["name"].as_str() == Some("AnalyzePower")
+            })
+            .expect("analysis node");
+        assert_eq!(
+            analysis["attributes"]["analysisEvaluationStatus"].as_str(),
+            Some("ok")
+        );
+        assert_eq!(
+            analysis["attributes"]["analysisComputedValue"].as_f64(),
+            Some(-4.5)
+        );
+        assert_eq!(
+            analysis["attributes"]["analysisConstraintPassed"].as_bool(),
+            Some(true)
+        );
     });
 }
 

--- a/crates/sysml_diagnostics/src/checks/requirement_case_conformance.rs
+++ b/crates/sysml_diagnostics/src/checks/requirement_case_conformance.rs
@@ -456,7 +456,7 @@ pub(crate) fn collect_requirement_case_conformance_diagnostics(
                         "semantic",
                         "case_objective_binding_cardinality",
                         format!(
-                            "Analysis case '{}' has objectives bound to analysis result but no return ref is declared.",
+                            "Analysis case '{}' has objectives bound to an analysis result but no returned result is declared.",
                             node.name
                         ),
                     ));

--- a/crates/sysml_diagnostics/src/helpers.rs
+++ b/crates/sysml_diagnostics/src/helpers.rs
@@ -672,8 +672,8 @@ Add a `subject` clause to the verification def before this objective \
         ),
         "analysis_result" => format!(
             "Analysis objective '{objective_name}' is not bound to a case result. \
-Add a `return ref` clause to the analysis def before this objective \
-(for example: `return ref analysisResult {{ return true; }}`)."
+Add a returned result to the analysis def before this objective \
+(for example: `return attribute analysisResult : Real = 1.0;`)."
         ),
         other => format!(
             "Objective '{objective_name}' could not be bound (expected binding: {other}). \
@@ -737,9 +737,10 @@ mod objective_binding_message_tests {
     }
 
     #[test]
-    fn analysis_result_message_mentions_return_ref() {
+    fn analysis_result_message_mentions_returned_result() {
         let message = objective_binding_unresolved_message("runtimeObjective", "analysis_result");
-        assert!(message.contains("return ref"));
+        assert!(message.contains("return attribute"));
+        assert!(message.contains("case result"));
         assert!(!message.contains("analysis_result"));
     }
 }

--- a/crates/sysml_model/src/semantic/analysis_typing.rs
+++ b/crates/sysml_model/src/semantic/analysis_typing.rs
@@ -160,12 +160,82 @@ fn propagate_case_usage_from_typing(
     let Some(expression) = resolve_case_definition_expression(graph, &def_id) else {
         return;
     };
+    let result = effective_case_result(graph, &def_id).cloned();
     if let Some(usage_mut) = graph.get_node_mut(usage_id) {
         usage_mut.attributes.insert(
             ANALYSIS_EXPRESSION_KEY.to_string(),
             serde_json::json!(expression),
         );
+        if let Some(result) = result.as_ref() {
+            usage_mut
+                .attributes
+                .insert("analysisResultCount".to_string(), serde_json::json!(1));
+            usage_mut.attributes.insert(
+                "inheritedAnalysisResult".to_string(),
+                serde_json::json!(result.id.qualified_name.as_str()),
+            );
+            if let Some(mode) = result
+                .attributes
+                .get("analysisResultMode")
+                .and_then(|value| value.as_str())
+            {
+                usage_mut
+                    .attributes
+                    .insert("analysisResultMode".to_string(), serde_json::json!(mode));
+            }
+            if let Some(type_name) = result
+                .attributes
+                .get("returnType")
+                .and_then(|value| value.as_str())
+            {
+                usage_mut.attributes.insert(
+                    "analysisResultType".to_string(),
+                    serde_json::json!(type_name),
+                );
+            }
+        }
     }
+    if let Some(result) = result.as_ref() {
+        let objective_ids = graph
+            .get_node(usage_id)
+            .map(|usage| {
+                graph
+                    .children_of(usage)
+                    .into_iter()
+                    .filter(|child| child.element_kind == ElementKind::Objective)
+                    .map(|child| child.id.clone())
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        for objective_id in objective_ids {
+            if let Some(objective) = graph.get_node_mut(&objective_id) {
+                objective.attributes.insert(
+                    "objectiveBoundTo".to_string(),
+                    serde_json::json!(result.id.qualified_name.as_str()),
+                );
+            }
+        }
+    }
+}
+
+fn effective_case_result<'a>(
+    graph: &'a SemanticGraph,
+    case_def_id: &NodeId,
+) -> Option<&'a SemanticNode> {
+    let case_def = graph.get_node(case_def_id)?;
+    if let Some(result) = graph
+        .children_of(case_def)
+        .into_iter()
+        .find(|child| child.element_kind == ElementKind::AnalysisResult)
+    {
+        return Some(result);
+    }
+    let inherited = inherited_case_result_qualified(graph, case_def_id)?;
+    graph
+        .node_ids_by_qualified_name
+        .get(&inherited)?
+        .iter()
+        .find_map(|id| graph.get_node(id))
 }
 
 fn usage_has_local_analysis_expression(usage: &SemanticNode) -> bool {
@@ -316,6 +386,15 @@ pub(crate) fn inherited_case_expression(
     if let Some(result_qualified) = inherited_result_qualified {
         let result_id = NodeId::new(&case_def_id.uri, result_qualified);
         if let Some(result_node) = graph.get_node(&result_id) {
+            if let Some(expression) = result_node
+                .attributes
+                .get("value")
+                .and_then(|value| value.as_str())
+                .map(str::trim)
+                .filter(|expression| !expression.is_empty())
+            {
+                return Some(expression.to_string());
+            }
             if let Some(body) = result_node
                 .attributes
                 .get("returnBody")

--- a/crates/sysml_model/src/semantic/evaluation/mod.rs
+++ b/crates/sysml_model/src/semantic/evaluation/mod.rs
@@ -6,7 +6,7 @@ use crate::semantic::analysis_typing::{
     typed_case_definition_scope_prefixes, typed_requirement_definition_scope_prefixes,
 };
 use crate::semantic::graph::SemanticGraph;
-use crate::semantic::model::{ElementKind, NodeId, SemanticNode};
+use crate::semantic::model::{ElementKind, NodeId, RelationshipKind, SemanticNode};
 use crate::semantic::reference_resolution::{resolve_member_via_type, ResolveResult};
 
 mod units;
@@ -142,7 +142,44 @@ fn evaluate_analysis_constraints(graph: &mut SemanticGraph, units: UnitRegistry)
                 }
             } else if let Some(expr) = single_expression.as_deref() {
                 evaluated = true;
-                if let Some(verdict_token) = resolve_verdict_kind_token(graph, &node_id, expr) {
+                let result_mode = node
+                    .attributes
+                    .get("analysisResultMode")
+                    .and_then(Value::as_str);
+                if result_mode == Some("value") {
+                    let outcome = engine.evaluate_expression_text(&node_id, expr);
+                    status = outcome.status.as_str().to_string();
+                    error = outcome.error;
+                    value = outcome.value.clone();
+                    if outcome.status == EvalStatus::Ok {
+                        if let Some(number) = outcome.value.as_ref().and_then(json_value_to_f64) {
+                            let result = Quantity {
+                                value: number,
+                                unit: outcome.unit,
+                            };
+                            computed = Some(result.clone());
+                            match evaluate_numeric_result_objectives(&mut engine, &node_id, &result)
+                            {
+                                Ok(Some((objective_passed, objective_limit))) => {
+                                    passed = Some(objective_passed);
+                                    limit = objective_limit;
+                                    status = if objective_passed {
+                                        STATUS_OK.to_string()
+                                    } else {
+                                        "failed_constraint".to_string()
+                                    };
+                                }
+                                Ok(None) => {}
+                                Err(err) => {
+                                    status = err.status.as_str().to_string();
+                                    error = Some(err.message);
+                                }
+                            }
+                        }
+                    }
+                } else if let Some(verdict_token) =
+                    resolve_verdict_kind_token(graph, &node_id, expr)
+                {
                     let is_pass = verdict_token == "pass";
                     status = STATUS_OK.to_string();
                     value = Some(Value::Bool(is_pass));
@@ -227,6 +264,83 @@ fn evaluate_analysis_constraints(graph: &mut SemanticGraph, units: UnitRegistry)
             );
         }
     }
+}
+
+fn evaluate_numeric_result_objectives(
+    engine: &mut EvalEngine<'_>,
+    analysis_id: &NodeId,
+    result: &Quantity,
+) -> Result<Option<(bool, Option<Quantity>)>, AnalysisEvalError> {
+    let Some(analysis) = engine.graph.get_node(analysis_id) else {
+        return Ok(None);
+    };
+    let objectives = engine
+        .graph
+        .children_of(analysis)
+        .into_iter()
+        .filter(|child| child.element_kind == ElementKind::Objective)
+        .cloned()
+        .collect::<Vec<_>>();
+    let mut evaluated_any = false;
+    let mut all_passed = true;
+    let mut first_limit = None;
+
+    for objective in objectives {
+        let requirement_defs = engine
+            .graph
+            .outgoing_targets_by_kind(&objective, RelationshipKind::Typing)
+            .into_iter()
+            .filter(|target| target.element_kind == ElementKind::RequirementDef)
+            .cloned()
+            .collect::<Vec<_>>();
+        for requirement_def in requirement_defs {
+            let constraints = requirement_def
+                .attributes
+                .get(ANALYSIS_CONSTRAINTS_KEY)
+                .and_then(Value::as_array)
+                .cloned()
+                .unwrap_or_default();
+            if constraints.is_empty() {
+                continue;
+            }
+            let subject_name = engine
+                .graph
+                .children_of(&requirement_def)
+                .into_iter()
+                .find(|child| child.element_kind == ElementKind::Subject)
+                .map(|subject| subject.name.clone());
+            let Some(subject_name) = subject_name else {
+                continue;
+            };
+            let mut bindings = HashMap::new();
+            bindings.insert(subject_name, BoundValue::Quantity(result.clone()));
+            engine.parameter_bindings.push(bindings);
+            for constraint in constraints {
+                let Some(expression) = constraint
+                    .as_object()
+                    .and_then(|object| object.get("expression"))
+                    .and_then(Value::as_str)
+                else {
+                    continue;
+                };
+                evaluated_any = true;
+                if first_limit.is_none() {
+                    first_limit =
+                        evaluate_analysis_limit_quantity(engine, &requirement_def.id, expression);
+                }
+                match evaluate_analysis_expression(engine, &requirement_def.id, expression) {
+                    Ok(constraint_passed) => all_passed &= constraint_passed,
+                    Err(err) => {
+                        engine.parameter_bindings.pop();
+                        return Err(err);
+                    }
+                }
+            }
+            engine.parameter_bindings.pop();
+        }
+    }
+
+    Ok(evaluated_any.then_some((all_passed, first_limit)))
 }
 
 #[cfg(test)]

--- a/crates/sysml_model/src/semantic/graph_builder/analysis_case.rs
+++ b/crates/sysml_model/src/semantic/graph_builder/analysis_case.rs
@@ -89,6 +89,10 @@ pub(super) fn build_from_analysis_body(
                     "returnBody".to_string(),
                     serde_json::json!(value.body.as_str()),
                 );
+                attrs.insert(
+                    "analysisResultMode".to_string(),
+                    serde_json::json!("predicate"),
+                );
                 if let Some(multiplicity) = value.multiplicity.as_deref() {
                     attrs.insert("multiplicity".to_string(), serde_json::json!(multiplicity));
                 }
@@ -110,6 +114,64 @@ pub(super) fn build_from_analysis_body(
                             parent_node.attributes.insert(
                                 "analysisExpression".to_string(),
                                 serde_json::json!(expression),
+                            );
+                            parent_node.attributes.insert(
+                                "analysisResultMode".to_string(),
+                                serde_json::json!("predicate"),
+                            );
+                        }
+                    }
+                }
+            }
+            UseCaseDefBodyElement::CaseReturnDecl(return_decl) => {
+                let value = &return_decl.value;
+                let qualified = qualified_name_for_node(
+                    g,
+                    uri,
+                    Some(parent_id.qualified_name.as_str()),
+                    &value.name,
+                    "analysis result",
+                );
+                let mut attrs = HashMap::new();
+                attrs.insert("analysisResultMode".to_string(), serde_json::json!("value"));
+                attrs.insert(
+                    "isRedefinition".to_string(),
+                    serde_json::json!(value.is_redefine),
+                );
+                if let Some(type_name) = value.type_name.as_deref() {
+                    attrs.insert("returnType".to_string(), serde_json::json!(type_name));
+                }
+                let expression = value
+                    .value_expression
+                    .as_ref()
+                    .map(expressions::expression_to_debug_string);
+                if let Some(expression) = expression.as_deref() {
+                    attrs.insert("value".to_string(), serde_json::json!(expression));
+                }
+                add_node_and_recurse(
+                    g,
+                    uri,
+                    &qualified,
+                    "analysis result",
+                    value.name.clone(),
+                    span_to_range(&return_decl.span),
+                    attrs,
+                    Some(parent_id),
+                );
+                if let Some(type_name) = value.type_name.as_deref() {
+                    add_typing_edge_if_exists(g, uri, &qualified, type_name, container_prefix);
+                }
+                if analysis_result_qualified.is_none() {
+                    analysis_result_qualified = Some(qualified);
+                    if let Some(expression) = expression {
+                        if let Some(parent_node) = g.get_node_mut(parent_id) {
+                            parent_node.attributes.insert(
+                                "analysisExpression".to_string(),
+                                serde_json::json!(expression),
+                            );
+                            parent_node.attributes.insert(
+                                "analysisResultMode".to_string(),
+                                serde_json::json!("value"),
                             );
                         }
                     }
@@ -296,8 +358,7 @@ pub(super) fn build_from_analysis_body(
             | UseCaseDefBodyElement::IncludeUseCase(_)
             | UseCaseDefBodyElement::ForLoop(_)
             | UseCaseDefBodyElement::ThenAction(_)
-            | UseCaseDefBodyElement::Annotation(_)
-            | UseCaseDefBodyElement::CaseReturnDecl(_) => {}
+            | UseCaseDefBodyElement::Annotation(_) => {}
             UseCaseDefBodyElement::FlowUsage(flow) => {
                 super::flow_usage::materialize_flow_usage(
                     flow,

--- a/crates/sysml_model/src/semantic/graph_builder/interface_def.rs
+++ b/crates/sysml_model/src/semantic/graph_builder/interface_def.rs
@@ -205,7 +205,7 @@ pub(super) fn build_from_interface_def_body_element(
             Some(parent_id),
             item,
         ),
-        E::ItemUsage(_) | E::PortUsage(_) => {}
+        E::ItemUsage(_) | E::PortUsage(_) | E::Error(_) => {}
         E::PortDef(port) => super::package_body::materialize_port_def(
             g,
             uri,
@@ -262,7 +262,12 @@ pub(super) fn build_from_connection_def_body_element(
             Some(parent_id),
             port,
         ),
-        E::ItemUsage(_) | E::PortUsage(_) | E::Error(_) => {}
+        E::ItemUsage(_)
+        | E::PortUsage(_)
+        | E::AssertConstraint(_)
+        | E::OccurrenceUsage(_)
+        | E::SuccessionUsage(_)
+        | E::Error(_) => {}
     }
 }
 

--- a/crates/sysml_model/tests/numeric_analysis_results.rs
+++ b/crates/sysml_model/tests/numeric_analysis_results.rs
@@ -1,0 +1,227 @@
+use sysml_diagnostics::{collect_diagnostics_from_graph, DiagnosticsOptions};
+use sysml_model::{
+    build_semantic_graph_from_documents, evaluate_expressions, ElementKind, SysmlDocument,
+    SysmlDocumentSourceKind,
+};
+
+const NUMERIC_ANALYSIS_SYSML: &str = r#"
+package PowerBudget {
+    attribute def OpticalPowerLevelDbm :> Real;
+
+    requirement def MinimumTransmitOutputPower {
+        subject outputPowerDbm : OpticalPowerLevelDbm;
+        attribute minimumOutputPowerDbm : OpticalPowerLevelDbm = -6.0;
+        require constraint {
+            outputPowerDbm >= minimumOutputPowerDbm
+        }
+    }
+
+    analysis nominalTransmitPowerBudget {
+        attribute carrierInputPowerDbm : OpticalPowerLevelDbm = 3.0;
+        attribute totalInsertionLossDb : Real = 7.5;
+
+        return attribute fibreOutputPowerDbm : OpticalPowerLevelDbm =
+            carrierInputPowerDbm - totalInsertionLossDb;
+
+        objective outputPowerObjective : MinimumTransmitOutputPower;
+    }
+
+    analysis def ReusablePowerBudget {
+        attribute carrierInputPowerDbm : OpticalPowerLevelDbm = 3.0;
+        attribute totalInsertionLossDb : Real = 7.5;
+        return attribute fibreOutputPowerDbm : OpticalPowerLevelDbm =
+            carrierInputPowerDbm - totalInsertionLossDb;
+    }
+
+    analysis inheritedPowerBudget : ReusablePowerBudget;
+}
+"#;
+
+const FAILING_NUMERIC_ANALYSIS_SYSML: &str = r#"
+package PowerBudget {
+    attribute def OpticalPowerLevelDbm :> Real;
+
+    requirement def StrictMinimumTransmitOutputPower {
+        subject outputPowerDbm : OpticalPowerLevelDbm;
+        attribute minimumOutputPowerDbm : OpticalPowerLevelDbm = -4.0;
+        require constraint { outputPowerDbm >= minimumOutputPowerDbm }
+    }
+
+    analysis insufficientTransmitPowerBudget {
+        attribute carrierInputPowerDbm : OpticalPowerLevelDbm = 3.0;
+        attribute totalInsertionLossDb : Real = 7.5;
+        return attribute fibreOutputPowerDbm : OpticalPowerLevelDbm =
+            carrierInputPowerDbm - totalInsertionLossDb;
+        objective outputPowerObjective : StrictMinimumTransmitOutputPower;
+    }
+}
+"#;
+
+fn build_graph() -> sysml_model::SemanticGraph {
+    build_graph_from_source(NUMERIC_ANALYSIS_SYSML)
+}
+
+fn build_graph_from_source(source: &str) -> sysml_model::SemanticGraph {
+    let document = SysmlDocument::from_memory_path(
+        "numeric-analysis-results",
+        "PowerBudget.sysml",
+        source.to_string(),
+        SysmlDocumentSourceKind::Workspace,
+        None,
+        None,
+    )
+    .expect("document URI");
+    let (mut graph, _) = build_semantic_graph_from_documents(&[document]).expect("semantic graph");
+    evaluate_expressions(&mut graph);
+    graph
+}
+
+fn node<'a>(
+    graph: &'a sysml_model::SemanticGraph,
+    qualified_name: &str,
+) -> &'a sysml_model::SemanticNode {
+    graph
+        .node_ids_by_qualified_name
+        .get(qualified_name)
+        .and_then(|ids| ids.first())
+        .and_then(|id| graph.get_node(id))
+        .unwrap_or_else(|| panic!("missing node {qualified_name}"))
+}
+
+fn number_attr(node: &sysml_model::SemanticNode, key: &str) -> Option<f64> {
+    node.attributes.get(key).and_then(|value| value.as_f64())
+}
+
+#[test]
+fn numeric_return_attribute_materializes_and_satisfies_objective_requirement() {
+    let graph = build_graph();
+    let analysis = node(&graph, "PowerBudget::nominalTransmitPowerBudget");
+    assert_eq!(
+        analysis
+            .attributes
+            .get("analysisResultMode")
+            .and_then(|value| value.as_str()),
+        Some("value")
+    );
+    assert_eq!(number_attr(analysis, "analysisComputedValue"), Some(-4.5));
+    assert_eq!(
+        analysis
+            .attributes
+            .get("analysisEvaluationStatus")
+            .and_then(|value| value.as_str()),
+        Some("ok")
+    );
+    assert_eq!(
+        analysis
+            .attributes
+            .get("analysisConstraintPassed")
+            .and_then(|value| value.as_bool()),
+        Some(true)
+    );
+    assert_eq!(number_attr(analysis, "analysisLimitValue"), Some(-6.0));
+    assert_eq!(
+        number_attr(analysis, "analysisComputedValue").unwrap()
+            - number_attr(analysis, "analysisLimitValue").unwrap(),
+        1.5
+    );
+
+    let result = node(
+        &graph,
+        "PowerBudget::nominalTransmitPowerBudget::fibreOutputPowerDbm",
+    );
+    assert_eq!(result.element_kind, ElementKind::AnalysisResult);
+    assert_eq!(
+        result
+            .attributes
+            .get("returnType")
+            .and_then(|value| value.as_str()),
+        Some("OpticalPowerLevelDbm")
+    );
+    assert_eq!(number_attr(result, "evaluatedValue"), Some(-4.5));
+
+    let objective = node(
+        &graph,
+        "PowerBudget::nominalTransmitPowerBudget::outputPowerObjective",
+    );
+    assert_eq!(
+        objective
+            .attributes
+            .get("objectiveBoundTo")
+            .and_then(|value| value.as_str()),
+        Some("PowerBudget::nominalTransmitPowerBudget::fibreOutputPowerDbm")
+    );
+
+    let diagnostics =
+        collect_diagnostics_from_graph(&graph, &analysis.id.uri, DiagnosticsOptions::default());
+    for forbidden in [
+        "objective_binding_unresolved",
+        "case_objective_binding_cardinality",
+        "analysis_constraint_failed",
+    ] {
+        assert!(
+            diagnostics
+                .iter()
+                .all(|diagnostic| diagnostic.code != forbidden),
+            "unexpected {forbidden}: {diagnostics:#?}"
+        );
+    }
+}
+
+#[test]
+fn numeric_result_fails_when_bound_objective_requirement_is_not_met() {
+    let graph = build_graph_from_source(FAILING_NUMERIC_ANALYSIS_SYSML);
+    let analysis = node(&graph, "PowerBudget::insufficientTransmitPowerBudget");
+    assert_eq!(number_attr(analysis, "analysisComputedValue"), Some(-4.5));
+    assert_eq!(number_attr(analysis, "analysisLimitValue"), Some(-4.0));
+    assert_eq!(
+        analysis
+            .attributes
+            .get("analysisConstraintPassed")
+            .and_then(|value| value.as_bool()),
+        Some(false)
+    );
+    assert_eq!(
+        analysis
+            .attributes
+            .get("analysisEvaluationStatus")
+            .and_then(|value| value.as_str()),
+        Some("failed_constraint")
+    );
+
+    let diagnostics =
+        collect_diagnostics_from_graph(&graph, &analysis.id.uri, DiagnosticsOptions::default());
+    assert!(
+        diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "analysis_constraint_failed"),
+        "expected failed objective diagnostic: {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn typed_analysis_usage_inherits_numeric_result_metadata_and_value() {
+    let graph = build_graph();
+    let usage = node(&graph, "PowerBudget::inheritedPowerBudget");
+    assert_eq!(
+        usage
+            .attributes
+            .get("analysisResultMode")
+            .and_then(|value| value.as_str()),
+        Some("value")
+    );
+    assert_eq!(
+        usage
+            .attributes
+            .get("analysisResultType")
+            .and_then(|value| value.as_str()),
+        Some("OpticalPowerLevelDbm")
+    );
+    assert_eq!(number_attr(usage, "analysisComputedValue"), Some(-4.5));
+    assert_eq!(
+        usage
+            .attributes
+            .get("analysisEvaluationStatus")
+            .and_then(|value| value.as_str()),
+        Some("ok")
+    );
+}


### PR DESCRIPTION
## Summary
- upgrade sysml-v2-parser to 0.53.0 and materialize typed analysis return attributes
- evaluate numeric results separately from Boolean and verdict returns
- bind typed objectives to numeric results, including inherited analysis usages
- update diagnostics and add semantic, LSP, and model-summary regressions

## Validation
- cargo test -p sysml_model --lib
- cargo test -p sysml_model --test numeric_analysis_results
- existing analysis and verification return-ref regression tests
- targeted LSP numeric analysis result test
- targeted MCP model-summary numeric result test
- cargo check --workspace
- cargo clippy --workspace --all-targets -- -D warnings

Depends on the released sysml-v2-parser 0.53.0 from elan8/sysml-v2-parser#57.

Closes #16