### PR TITLE
Avoid poison-panicking on query_indexes Mutex lock

### DIFF
--- a/crates/sysml_model/src/semantic/graph.rs
+++ b/crates/sysml_model/src/semantic/graph.rs
@@ -321,10 +321,12 @@ impl SemanticGraphData {
     }
 
     fn query_indexes(&self) -> Arc<GraphQueryIndexes> {
+        // Recover from poison instead of panicking the whole analysis pipeline;
+        // a poisoned cache is rebuilt below just like an empty one.
         let mut guard = self
             .query_indexes
             .lock()
-            .expect("semantic graph query indexes lock");
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         if let Some(indexes) = guard.as_ref() {
             return Arc::clone(indexes);
         }


### PR DESCRIPTION
## Summary
- `query_indexes()` recovers from a poisoned mutex instead of panicking via `.expect(...)`, mirroring the `.ok()`/`if let Ok` pattern already used by the shape and import-lookup caches in the same file.
- On poison, the guard is recovered and the cache is rebuilt, same as the empty-cache path.

## Test plan
- [x] `cargo check -p sysml_model`

Fixes #40