### PR TITLE
Project EnumerationUsage inside part-usage bodies

### DIFF
--- a/crates/sysml_model/src/semantic/graph_builder/package_body/materialize.rs
+++ b/crates/sysml_model/src/semantic/graph_builder/package_body/materialize.rs
@@ -766,7 +766,7 @@ fn materialize_enumerated_values(
     }
 }
 
-pub(super) fn materialize_enum_usage(
+pub(crate) fn materialize_enum_usage(
     g: &mut SemanticGraph,
     uri: &Url,
     container_prefix: Option<&str>,

--- a/crates/sysml_model/src/semantic/graph_builder/part_usage.rs
+++ b/crates/sysml_model/src/semantic/graph_builder/part_usage.rs
@@ -209,7 +209,16 @@ pub(super) fn build_from_part_usage_body_element(
         PUBE::Doc(doc) => {
             super::attach_doc_comment(g, parent_id, &doc.value.text);
         }
-        PUBE::EnumerationUsage(_) | PUBE::Annotation(_) | PUBE::Error(_) => {}
+        PUBE::EnumerationUsage(enum_node) => {
+            super::package_body::materialize_enum_usage(
+                g,
+                uri,
+                container_prefix,
+                Some(parent_id),
+                enum_node,
+            );
+        }
+        PUBE::Annotation(_) | PUBE::Error(_) => {}
         _ => {}
     }
 }

--- a/crates/sysml_model/tests/part_def_body_semantics.rs
+++ b/crates/sysml_model/tests/part_def_body_semantics.rs
@@ -85,6 +85,43 @@ fn part_def_enum_usage_materializes_inner_attribute() {
 }
 
 #[test]
+fn part_usage_enum_usage_materializes_inner_attribute() {
+    // Issue #25: `enum` inside a `part` *usage* body (as opposed to a `part def` body, covered
+    // by `part_def_enum_usage_materializes_inner_attribute` above) was silently dropped by
+    // `PartUsageBodyElement::EnumerationUsage(_) => {}` in part_usage.rs.
+    let doc = workspace_doc(
+        "enum_in_part_usage.sysml",
+        r#"package P {
+  enum def Status;
+  part def Vehicle;
+  part vehicle : Vehicle {
+    enum status : Status {
+      attribute code : String;
+    }
+  }
+}"#,
+    );
+    let (graph, _parsed) = build_semantic_graph_from_documents(&[doc]).expect("graph");
+    let vehicle = graph
+        .nodes_named("vehicle")
+        .into_iter()
+        .find(|node| node.element_kind == "part")
+        .expect("part usage");
+    let enum_usage = graph
+        .children_of(vehicle)
+        .into_iter()
+        .find(|child| child.element_kind == "enumeration" && child.name == "status")
+        .expect("enumeration usage");
+    assert!(
+        graph.children_of(enum_usage).iter().any(|child| {
+            (child.element_kind == "attribute" || child.element_kind == "attribute def")
+                && child.name == "code"
+        }),
+        "expected attribute under enumeration usage"
+    );
+}
+
+#[test]
 fn part_def_item_usage_materializes_inner_attribute() {
     let doc = workspace_doc(
         "item.sysml",


### PR DESCRIPTION
## Summary
- `PartUsageBodyElement::EnumerationUsage(_)` was matched into a no-op in `part_usage.rs`, silently dropping spec-legal `enum` members declared inside a `part` usage body from the graph.
- Reuses the shared `materialize_enum_usage` helper (already used by `package_body`, and duplicated inline in `part_def`) rather than duplicating the logic a third time. Widened its visibility from `pub(super)` to `pub(crate)` so `part_usage.rs` can call it.
- Adds `part_usage_enum_usage_materializes_inner_attribute`, mirroring the existing `part_def_enum_usage_materializes_inner_attribute` test but for a `part` usage body instead of a `part def` body.

## Test plan
- [x] `cargo test -p sysml_model --test part_def_body_semantics` (14 passed, including new test)
- [x] `cargo test -p sysml_model` (only pre-existing, unrelated `typescript_bindings` CRLF/LF failure remains, confirmed present on `main` too)

Fixes #25