### PR TITLE
Close S42-LIM-015: named/about-bound metadata usages already work in part def bodies

### DIFF
--- a/crates/sysml_model/tests/metadata_semantics.rs
+++ b/crates/sysml_model/tests/metadata_semantics.rs
@@ -238,6 +238,104 @@ fn metadata_usage_about_clause_wires_annotation_edges() {
 }
 
 #[test]
+fn part_def_body_allows_multiple_named_about_bound_usages_of_the_same_metadata_def() {
+    // Issue #24 / S42-LIM-015: applying the same `metadata def` more than once inside one
+    // `part def` body needs each usage to have a distinct name (and, typically, an `about`
+    // binding to the specific member it characterizes) so the usages don't collide as anonymous
+    // same-named members (`duplicate_namespace_member`). Both the `@name : Type about target
+    // { ... }` prefix form and the equivalent `metadata name : Type about target { ... }` form
+    // are BNF-legal (`MetadataUsage = ('@' | 'metadata') MetadataUsageDeclaration ('about'
+    // Annotation)? MetadataBody`, §8.2.2.27) and already parse cleanly -- the two forms
+    // previously written up as failing in DIAGNOSTIC-CATALOG.md's S42-LIM-015 entry used
+    // non-BNF syntax (`@Type name { ... }` with the type and name in the wrong order, and
+    // `about` placed *after* the body instead of before it), not a real parser or graph gap.
+    let doc = SysmlDocument::from_memory_path(
+        "metadata-part-def-multiple-usages",
+        "power_module.sysml",
+        r#"package P {
+  metadata def PowerRailBudget {
+    attribute nominalVoltage;
+  }
+  port def PowerRailPort;
+  part def PowerModule {
+    port batteryRail : PowerRailPort;
+    port logicRail : PowerRailPort;
+
+    @batteryRailBudget : PowerRailBudget about batteryRail {
+      nominalVoltage = 14.4;
+    }
+    @logicRailBudget : PowerRailBudget about logicRail {
+      nominalVoltage = 3.3;
+    }
+  }
+}"#
+        .to_string(),
+        SysmlDocumentSourceKind::Workspace,
+        None,
+        None,
+    )
+    .expect("document uri");
+    let uri = doc.uri.clone();
+    let (graph, _parsed) = build_semantic_graph_from_documents(&[doc]).expect("graph");
+
+    let power_module = graph
+        .nodes_named("PowerModule")
+        .into_iter()
+        .find(|node| node.element_kind == "part def")
+        .expect("PowerModule part def");
+    let battery_rail = graph
+        .children_of(power_module)
+        .into_iter()
+        .find(|child| child.name == "batteryRail")
+        .expect("batteryRail port");
+    let logic_rail = graph
+        .children_of(power_module)
+        .into_iter()
+        .find(|child| child.name == "logicRail")
+        .expect("logicRail port");
+
+    let battery_budget = graph
+        .children_of(power_module)
+        .into_iter()
+        .find(|child| child.element_kind == "metadata usage" && child.name == "batteryRailBudget")
+        .expect("batteryRailBudget metadata usage");
+    let logic_budget = graph
+        .children_of(power_module)
+        .into_iter()
+        .find(|child| child.element_kind == "metadata usage" && child.name == "logicRailBudget")
+        .expect("logicRailBudget metadata usage");
+
+    assert!(
+        graph
+            .outgoing_targets_by_kind(battery_budget, RelationshipKind::Annotation)
+            .iter()
+            .any(|target| target.id == battery_rail.id),
+        "expected batteryRailBudget's annotation edge to point at batteryRail, not logicRail"
+    );
+    assert!(
+        graph
+            .outgoing_targets_by_kind(logic_budget, RelationshipKind::Annotation)
+            .iter()
+            .any(|target| target.id == logic_rail.id),
+        "expected logicRailBudget's annotation edge to point at logicRail, not batteryRail"
+    );
+
+    let diagnostics = collect_diagnostics_from_graph(&graph, &uri, DiagnosticsOptions::default());
+    let unexpected: Vec<_> = diagnostics
+        .iter()
+        .filter(|diag| {
+            diag.code == "duplicate_namespace_member"
+                || diag.code == "unsupported_annotation_syntax"
+        })
+        .map(|diag| format!("{}: {}", diag.code, diag.message))
+        .collect();
+    assert!(
+        unexpected.is_empty(),
+        "unexpected diagnostics for distinct named/about-bound metadata usages: {unexpected:?}"
+    );
+}
+
+#[test]
 fn metadata_keyword_usage_resolves_with_typing_edge() {
     let doc = SysmlDocument::from_memory_path(
         "metadata-keyword-typed",

--- a/docs/engineering/DIAGNOSTIC-CATALOG.md
+++ b/docs/engineering/DIAGNOSTIC-CATALOG.md
@@ -219,45 +219,39 @@ Tracked limitations (`S42-LIM-*`) addressed in this cycle:
 - `S42-LIM-008`: cyclic state machines suppress `missing_final_state` guidance (`behavior_conformance.rs`).
 - `S42-LIM-009`: bundled `MonetaryUnits` indexed for `[EUR]` (`evaluation/units.rs`).
 - `S42-LIM-010`: remove implicit redefines heuristic false positives (`kind_compatibility.rs`).
-- `S42-LIM-015`: named and `about`-bound metadata usages rejected inside a `part def` body — tracked in [#24](https://github.com/elan8/spec42/issues/24).
+- `S42-LIM-015`: named and `about`-bound metadata usages inside a `part def` body — closed, see below.
 
 Optional env-gated integration baseline: `SYSML_ROBOT_VACUUM_DIR` → `robot_vacuum_baseline.rs`.
 
 Done: `S42-LIM-005` — generic `FlowUsage` in parser and semantic graph (`flow` / `message` / `succession flow` in structure-usage bodies including part def/usage, package, occurrence def, action, use case).
 
-### S42-LIM-015: named/`about`-bound metadata usages unsupported in part-definition bodies
+### S42-LIM-015: named/`about`-bound metadata usages in part-definition bodies
 
-**Status:** tracked in [#24](https://github.com/elan8/spec42/issues/24) (not maintained as a TODO in this doc).
+**Status:** closed. [#24](https://github.com/elan8/spec42/issues/24) investigated this and found the parser and semantic graph already handle the BNF-legal named/`about`-bound forms correctly — the two forms originally written up below as failing both use syntax the BNF (§8.2.2.27) never allowed in the first place, not a real parser or graph gap. No parser or graph change was needed; regression coverage
+(`part_def_body_allows_multiple_named_about_bound_usages_of_the_same_metadata_def`, `crates/sysml_model/tests/metadata_semantics.rs`) now locks in the correct behavior.
 
-**Symptom**: applying the same `metadata def` more than once inside one `part def` body — which requires giving each usage a distinct name or explicit target so they don't collide as anonymous same-named members — has no working syntax today. Two forms were tried, both rejected:
+**Original symptom**: applying the same `metadata def` more than once inside one `part def` body — which requires giving each usage a distinct name or explicit target so they don't collide as anonymous same-named members — appeared to have no working syntax. Two forms were tried, both rejected:
 
-1. Named prefix-annotation form:
-   ```sysml
-   part def PowerModule {
-     @PowerRailBudget batteryRailBudget {
-       nominalVoltage = 14.4 [V];
-     }
-     port batteryRail : PowerRailPort;
-   }
-   ```
-   Result: `warning [unsupported_annotation_syntax] unsupported annotation syntax in part definition body`.
+1. `@PowerRailBudget batteryRailBudget { ... }` — invalid: per `MetadataUsageDeclaration = (Identification (':' | 'typed' 'by'))? OwnedFeatureTyping`, a name must be followed by `:` (or `typed by`) *before* the type, not placed after it as a bare second word.
+2. `metadata batteryRailBudget : PowerRailBudget { ... } about batteryRail;` — invalid: `about` comes *before* `MetadataBody` per the BNF (`MetadataUsageDeclaration ('about' Annotation...)? MetadataBody`), not after the closing `}`.
 
-2. Explicit `metadata ... about ...;` binding form:
-   ```sysml
-   part def PowerModule {
-     port batteryRail : PowerRailPort;
-     metadata batteryRailBudget : PowerRailBudget {
-       nominalVoltage = 14.4 [V];
-     } about batteryRail;
-   }
-   ```
-   Result: `error [unexpected_keyword_in_scope] unexpected keyword 'about' in part definition body`.
+**Correct syntax** (BNF-legal, confirmed parsing and materializing cleanly on the graph with distinct `Annotation` edges per usage and no `duplicate_namespace_member`):
 
-The unnamed, unbound form (`@PowerRailBudget { ... }` with no name and no `about`) parses fine for a *single* occurrence per definition — the failure only appears once a second occurrence of the same metadata def is needed in the same namespace, which then hits `duplicate_namespace_member` instead (three anonymous usages of `@PowerRailBudget` in one `part def` all default to the member name `PowerRailBudget`).
+```sysml
+part def PowerModule {
+  port batteryRail : PowerRailPort;
+  port logicRail : PowerRailPort;
 
-**Expected behavior**: per the SysML v2 spec, a prefix metadata annotation is sugar for a `metadata` usage, which should support an explicit name (`@MetadataDef usageName { ... }`) and/or an explicit `about` target the same way a standalone `metadata` declaration does at the package level. Neither form should be scoped out specifically inside a `part def`/`port` body.
+  @batteryRailBudget : PowerRailBudget about batteryRail {
+    nominalVoltage = 14.4 [V];
+  }
+  @logicRailBudget : PowerRailBudget about logicRail {
+    nominalVoltage = 3.3 [V];
+  }
+}
+```
 
-**Current workaround** (used in `sysml-robot-vacuum-cleaner/model/30_architecture/PhysicalArchitecture.sysml`): model the would-be metadata def as a plain `attribute def` instead, and declare one `attribute <name> : <def> { attribute :>> field = value; ... }` per port as a sibling attribute — same data, no annotation/binding syntax required, but it's an `attribute` rather than the more semantically precise `metadata` relationship to the port it characterizes.
+The equivalent `metadata batteryRailBudget : PowerRailBudget about batteryRail { ... }` (explicit keyword instead of `@`) works identically. Real-usage precedent for the unnamed `@Type about target { ... }` shape: OMG spec Annex `Vehicle Example/SysML v2 Spec Annex A SimpleVehicleModel.sysml` (`@Rationale about ...`, `@Risk about ...`).
 
 ## Suggested implementation order
 


### PR DESCRIPTION
## Summary

Investigated the reported gap: named and `about`-bound metadata usages rejected inside a `part def` body, blocking multiple annotations of the same `metadata def` in one namespace (each anonymous usage collides on `duplicate_namespace_member`).

**Finding**: both example forms written up in `DIAGNOSTIC-CATALOG.md`'s S42-LIM-015 entry used syntax the BNF (SysML v2 spec §8.2.2.27) never permitted:

1. `@PowerRailBudget batteryRailBudget { ... }` — invalid: `MetadataUsageDeclaration = (Identification (':' | 'typed' 'by'))? OwnedFeatureTyping` requires a name to be followed by `:`/`typed by` *before* the type, not placed after it as a bare second word.
2. `metadata batteryRailBudget : PowerRailBudget { ... } about batteryRail;` — invalid: `about` must come *before* `MetadataBody` per the BNF, not after the closing `}`.

The BNF-legal forms already parse and materialize correctly on the graph — confirmed both `@name : Type about target { ... }` and the equivalent explicit `metadata name : Type about target { ... }` produce distinct metadata usage nodes with correct `Annotation` edges to their respective `about` targets, with **zero** `duplicate_namespace_member` or `unsupported_annotation_syntax` diagnostics, even with two usages of the same `metadata def` in one `part def` body — the exact scenario the issue described as blocked. No parser or graph change was needed; `sysml-v2-parser` already handles this (confirmed against real usage precedent: OMG spec Annex `SimpleVehicleModel.sysml`'s `@Rationale about ...` / `@Risk about ...`).

## Changes
- Added `part_def_body_allows_multiple_named_about_bound_usages_of_the_same_metadata_def` (`crates/sysml_model/tests/metadata_semantics.rs`) as regression coverage for the exact previously-blocked scenario.
- Rewrote the S42-LIM-015 entry in `docs/engineering/DIAGNOSTIC-CATALOG.md` to close it with the corrected syntax and real-usage precedent, replacing the two invalid examples.

## Test plan
- [x] `cargo test -p sysml_model --test metadata_semantics` (11 passed, including the new test)
- [x] `cargo test -p sysml_model` — only the pre-existing, unrelated `typescript_bindings` CRLF/LF failure remains (confirmed present on `main` too, see #21's investigation)
- [x] `cargo fmt --check`, `cargo clippy -p sysml_model --all-targets` — clean

Fixes #24