### PR TITLE
Compact layout for packages with many same-depth siblings

### DIFF
--- a/crates/server/assets/diagram-renderer/headless-renderer.js
+++ b/crates/server/assets/diagram-renderer/headless-renderer.js
@@ -711,7 +711,7 @@ var Spec42HeadlessRendererBundle = (() => {
   function buildGeneralPackageContainerGroups(nodes) {
     const byPackage = /* @__PURE__ */ new Map();
     for (const node of nodes) {
-      const qn = asString(asRecord(node.attributes).qualifiedName);
+      const qn = asString(asRecord(node.attributes).qualifiedName) || node.id;
       const sep = qn.indexOf("::");
       if (sep <= 0) continue;
       const pkg = qn.slice(0, sep);
@@ -6810,9 +6810,27 @@ var Spec42HeadlessRendererBundle = (() => {
         height: Math.max(height, computeNodeHeight(compartments, { maxLinesPerCompartment: 8 }))
       };
     };
+    const WIDE_SIBLING_THRESHOLD = 8;
+    const chunkedElkChildren = (idPrefix, elkNodes) => {
+      if (elkNodes.length <= WIDE_SIBLING_THRESHOLD) return elkNodes;
+      const chunkSize = Math.max(1, Math.ceil(Math.sqrt(elkNodes.length) / 2));
+      const chunks = [];
+      for (let i = 0; i < elkNodes.length; i += chunkSize) {
+        chunks.push({
+          id: `${idPrefix}#chunk${chunks.length}`,
+          layoutOptions: {
+            "elk.direction": "DOWN",
+            "elk.padding": "[top=8,left=8,bottom=8,right=8]"
+          },
+          children: elkNodes.slice(i, i + chunkSize)
+        });
+      }
+      return chunks;
+    };
     const packageGroups = prepared.meta?.packageContainerGroups ?? [];
     const useHierarchy = packageGroups.length >= 2;
     let children2;
+    let flatChildrenWereChunked = false;
     if (useHierarchy) {
       const memberToPackage = /* @__PURE__ */ new Map();
       for (const group of packageGroups) {
@@ -6837,16 +6855,18 @@ var Spec42HeadlessRendererBundle = (() => {
           "elk.direction": "DOWN",
           "elk.padding": "[top=36,left=20,bottom=20,right=20]"
         },
-        children: byPackage.get(group.id) ?? []
+        children: chunkedElkChildren(group.id, byPackage.get(group.id) ?? [])
       }));
       children2 = [...containers, ...orphans];
     } else {
-      children2 = diagramNodes.map(leafElkNode);
+      const flatChildren = diagramNodes.map(leafElkNode);
+      children2 = chunkedElkChildren("root", flatChildren);
+      flatChildrenWereChunked = children2 !== flatChildren;
     }
     const graph = {
       id: "root",
       layoutOptions: buildElkLayoutOptions("general", {
-        "elk.hierarchyHandling": useHierarchy ? "INCLUDE_CHILDREN" : void 0
+        "elk.hierarchyHandling": useHierarchy || flatChildrenWereChunked ? "INCLUDE_CHILDREN" : void 0
       }),
       children: children2,
       edges: diagramEdges.map((edge) => ({ id: edge.id, sources: [edge.source], targets: [edge.target] }))

--- a/shared/diagram-renderer/src/prepare.test.ts
+++ b/shared/diagram-renderer/src/prepare.test.ts
@@ -84,6 +84,26 @@ describe("shared prepareViewData", () => {
     expect(groups?.map((g) => g.name).sort()).toEqual(["PkgA", "PkgB"]);
   });
 
+  it("builds package container groups when the raw payload has no separate qualifiedName field", () => {
+    // Regression test for O-4: graph nodes coming off the Rust side never carry a top-level or
+    // `attributes.qualifiedName` field -- `id` *is* the qualified name (e.g.
+    // "PhysicalArchitecture::BaseModule"). Without falling back to `id`, package grouping (and
+    // the compact-layout chunking it enables) silently never activated for any real payload.
+    const prepared = prepareViewData({
+      view: "general-view",
+      graph: {
+        nodes: [
+          { id: "PkgA::A", name: "A", type: "part def" },
+          { id: "PkgB::B", name: "B", type: "part def" },
+        ],
+        edges: [],
+      },
+    });
+    const groups = prepared.meta?.packageContainerGroups as Array<{ name: string; memberIds: string[] }>;
+    expect(groups).toHaveLength(2);
+    expect(groups?.map((g) => g.name).sort()).toEqual(["PkgA", "PkgB"]);
+  });
+
   it("marks reference usages on prepared nodes", () => {
     const prepared = prepareViewData({
       view: "general-view",

--- a/shared/diagram-renderer/src/prepare/graph.ts
+++ b/shared/diagram-renderer/src/prepare/graph.ts
@@ -13,7 +13,13 @@ function isGeneralViewDiagramNode(node: UnknownRecord): boolean {
 function buildGeneralPackageContainerGroups(nodes: PreparedNode[]): UnknownRecord[] {
   const byPackage = new Map<string, string[]>();
   for (const node of nodes) {
-    const qn = asString(asRecord(node.attributes).qualifiedName);
+    // `node.attributes.qualifiedName` is empty for every graph node coming off the Rust side --
+    // there's no separate `qualifiedName` field on the raw payload, `node.id` carries the
+    // qualified name instead (mirrors `qualifiedNameOf` in `standard-views.ts`, which already
+    // falls back to `node.id` for the same reason). Falling back to `id` only when the attribute
+    // is genuinely empty keeps the synthetic-fixture contract (an explicit `qualifiedName` that
+    // differs from a short `id`) working too.
+    const qn = asString(asRecord(node.attributes).qualifiedName) || node.id;
     const sep = qn.indexOf("::");
     if (sep <= 0) continue;
     const pkg = qn.slice(0, sep);

--- a/shared/diagram-renderer/src/render/layout.general-view.test.ts
+++ b/shared/diagram-renderer/src/render/layout.general-view.test.ts
@@ -71,4 +71,43 @@ describe("general-view layout package hierarchy", () => {
     expect(result.nodes).toHaveLength(2);
     expect(result.nodes.every((n) => typeof n.x === "number" && typeof n.y === "number")).toBe(true);
   });
+
+  // O-4: a same-depth sibling set large enough to dominate a single ELK layer -- a single
+  // package/def with many members and few edges between them -- otherwise lays out as one very
+  // wide row (elk.layered.wrapping.strategy doesn't split a single edge-sparse layer). Mirrors the
+  // robot-vacuum `baseDecomposition` fixture: one "owner" node with many direct "hierarchy"
+  // children and no edges between the children themselves.
+  it("chunks a wide same-parent sibling set into a more compact layout than one flat row", async () => {
+    const memberCount = 19;
+    const owner = partNode("Pkg::Owner", "Owner", "Pkg::Owner");
+    const members = Array.from({ length: memberCount }, (_, i) =>
+      partNode(`Pkg::member${i}`, `member${i}`, `Pkg::member${i}`),
+    );
+    const edges = members.map((member, i) => ({
+      id: `contains-${i}`,
+      source: owner.id,
+      target: member.id,
+      type: "contains",
+    }));
+    const graph = { nodes: [owner, ...members], edges };
+    const prepared = prepareViewData({ view: "general-view", generalViewGraph: graph });
+    // Single package: no package containers, so this exercises the flat-branch chunking path.
+    expect(prepared.meta).toBeUndefined();
+
+    const result = await layoutPrepared(prepared);
+    expect(result.nodes).toHaveLength(memberCount + 1);
+    expect(result.nodes.every((n) => typeof n.x === "number" && typeof n.y === "number")).toBe(true);
+    expect(result.edges).toHaveLength(memberCount);
+    expect(result.edges.every((e) => e.layout)).toBe(true);
+
+    const ys = result.nodes.map((n) => n.y ?? 0);
+    const height = Math.max(...ys) - Math.min(...ys);
+    // Before chunking, every sibling lands in the same ELK layer, so the diagram is only 2 rows
+    // tall regardless of member count (the owner's own row, plus one wide row for every sibling) --
+    // 250px for this exact fixture with WIDE_SIBLING_THRESHOLD disabled. Chunking spreads the
+    // members across several rows instead (446px with chunking on) -- the direct signal that the
+    // wide-row bug is actually fixed, independent of exactly how compact the resulting grid ends up
+    // for a given topology. 350 sits between the two, comfortably on the chunked side.
+    expect(height).toBeGreaterThan(350);
+  });
 });

--- a/shared/diagram-renderer/src/render/layout.ts
+++ b/shared/diagram-renderer/src/render/layout.ts
@@ -125,6 +125,47 @@ export async function layoutPrepared(prepared: PreparedView): Promise<LayoutResu
     };
   };
 
+  // O-4: a same-depth sibling set large enough to dominate a single ELK layer (e.g. a def with
+  // many members and few edges between them, robot-vacuum PhysicalArchitecture -- specifically
+  // BaseModule's 11 direct members exposed by the `baseDecomposition` view -- being the motivating
+  // case) otherwise lays out as one very wide row: `elk.layered.wrapping.strategy` does not split a
+  // single edge-sparse layer into multiple rows (confirmed empirically against that fixture: no
+  // effect at any wrapping strategy/aspect ratio combination tried, because the graph only has ~3
+  // real rank tiers -- too few for ELK's wrap cutting to find a useful cut point). Chunk any node
+  // set above the threshold into roughly-square synthetic sub-containers so ELK's hierarchical
+  // layered algorithm treats each chunk as its own compact block instead of one flat row; edges
+  // crossing chunk boundaries still route correctly via `elk.hierarchyHandling: INCLUDE_CHILDREN`
+  // at the root, the same mechanism already used for real package containers below. Chunking by
+  // containment ("hierarchy" edge) siblings only, keeping same-rank members together, was tried
+  // first and produced a *wider* result than plain array-order chunking on the motivating fixture
+  // (2792px vs 2273px bounding-box width) -- grouping every sibling set under its own container
+  // left the surrounding rank-1/rank-2 nodes (a shared def's own type-def targets, still one per
+  // distinct type) needing to route edges into several different chunks at once, which spread the
+  // layout back out; plain order-based chunking doesn't have that failure mode since everything
+  // (including those less-numerous neighbors) gets folded into the same compact chunk set.
+  // `baseDecomposition`'s 19-node bounding box went from 3600x820 (aspect ratio 4.4) unchunked to
+  // 2273x1158 (aspect ratio 2.0) with chunk size `ceil(sqrt(n)/2)` -- a fixed chunk size of 3 or
+  // the unhalved `ceil(sqrt(n))` were both tried and came out wider on this fixture. Synthetic
+  // chunk ids are never added to `packageContainerGroups`, so no extra frame is drawn around them
+  // -- this is layout-only and mustn't be confused with real package containment.
+  const WIDE_SIBLING_THRESHOLD = 8;
+  const chunkedElkChildren = (idPrefix: string, elkNodes: unknown[]): unknown[] => {
+    if (elkNodes.length <= WIDE_SIBLING_THRESHOLD) return elkNodes;
+    const chunkSize = Math.max(1, Math.ceil(Math.sqrt(elkNodes.length) / 2));
+    const chunks: unknown[] = [];
+    for (let i = 0; i < elkNodes.length; i += chunkSize) {
+      chunks.push({
+        id: `${idPrefix}#chunk${chunks.length}`,
+        layoutOptions: {
+          "elk.direction": "DOWN",
+          "elk.padding": "[top=8,left=8,bottom=8,right=8]",
+        },
+        children: elkNodes.slice(i, i + chunkSize),
+      });
+    }
+    return chunks;
+  };
+
   // General-view: give ELK real package containment (mirroring the IBD hierarchy pattern in
   // interconnection-elk-input.ts) so each package lays out as a compact block instead of a flat
   // layered graph scattering package members anywhere, which otherwise produces very wide,
@@ -135,6 +176,7 @@ export async function layoutPrepared(prepared: PreparedView): Promise<LayoutResu
       | undefined) ?? [];
   const useHierarchy = packageGroups.length >= 2;
   let children: unknown[];
+  let flatChildrenWereChunked = false;
   if (useHierarchy) {
     const memberToPackage = new Map<string, string>();
     for (const group of packageGroups) {
@@ -161,17 +203,19 @@ export async function layoutPrepared(prepared: PreparedView): Promise<LayoutResu
           "elk.direction": "DOWN",
           "elk.padding": "[top=36,left=20,bottom=20,right=20]",
         },
-        children: byPackage.get(group.id) ?? [],
+        children: chunkedElkChildren(group.id, byPackage.get(group.id) ?? []),
       }));
     children = [...containers, ...orphans];
   } else {
-    children = diagramNodes.map(leafElkNode);
+    const flatChildren = diagramNodes.map(leafElkNode);
+    children = chunkedElkChildren("root", flatChildren);
+    flatChildrenWereChunked = children !== flatChildren;
   }
 
   const graph = {
     id: "root",
     layoutOptions: buildElkLayoutOptions("general", {
-      "elk.hierarchyHandling": useHierarchy ? "INCLUDE_CHILDREN" : undefined,
+      "elk.hierarchyHandling": useHierarchy || flatChildrenWereChunked ? "INCLUDE_CHILDREN" : undefined,
     }),
     children,
     edges: diagramEdges.map((edge) => ({ id: edge.id, sources: [edge.source], targets: [edge.target] }))


### PR DESCRIPTION
## Summary

Two compounding bugs caused packages/defs with many same-depth members (robot-vacuum `PhysicalArchitecture::BaseModule`'s 11 direct members, exposed by the `baseDecomposition` general view) to lay out as one very wide ELK row (3600x820, aspect ratio 4.4).

**Bug 1 — F-8 package containment was silently dead for all real payloads.** `buildGeneralPackageContainerGroups` read the package prefix from `node.attributes.qualifiedName`, which is always empty for graph nodes coming off the Rust side — there's no separate `qualifiedName` field on the raw payload, `node.id` carries it instead (e.g. `"PhysicalArchitecture::BaseModule"`). Package containment only ever worked for test fixtures that happened to set an explicit `qualifiedName` distinct from `id`. Now falls back to `node.id`, only when the attribute is genuinely empty, so the existing synthetic-fixture contract still holds.

**Bug 2 — even with containment fixed, a single wide package/def still needs chunking.** `elk.layered.wrapping.strategy` does not split a single edge-sparse ELK layer into multiple rows — confirmed empirically against the motivating fixture: no effect at any wrapping-strategy/aspect-ratio combination tried, because the graph only has ~3 real rank tiers, too few for ELK's wrap-cutting to find a useful cut point. `layoutPrepared` now chunks any node set above a threshold (8) into roughly-square synthetic sub-containers, reusing the exact `elk.hierarchyHandling: INCLUDE_CHILDREN` mechanism already used for real package containers, so edges crossing chunk boundaries still route correctly. Chunk ids are never added to `packageContainerGroups`, so no extra visual frame gets drawn — this is layout-only.

**Results** (robot-vacuum `sysml-robot-vacuum-cleaner` fixture, all views checked for regressions):
| View | Before | After |
|---|---|---|
| `baseDecomposition` | 3600×820 (aspect 4.4) | 2273×1158 (aspect 2.0) |
| `productDecomposition` (2 real packages) | 1980×1900, **0 frames** (bug 1) | 1412×1247, **2 frames** (correct) |
| `topDecomposition` | 1980×900 | 1432×812 |
| `mainPcbDecomposition` | 1980×900 | 1652×792 |
| `powerDecomposition` | 1640×900 | 1117×792 |

No regressions in node/edge counts; single-package views still get zero frames, matching prior behavior.

## Changes
- `shared/diagram-renderer/src/prepare/graph.ts` — qualifiedName fallback fix.
- `shared/diagram-renderer/src/render/layout.ts` — chunking for wide sibling sets (both the flat and real-package-container branches).
- Regression tests: `prepare.test.ts` (qualifiedName-less payload, mirrors real Rust shape) and `layout.general-view.test.ts` (wide-sibling chunking) — verified both fail without their corresponding fix.
- Rebuilt `crates/server/assets/diagram-renderer/headless-renderer.js` so the CLI/QuickJS export path picks up the fix.

## Test plan
- [x] `npx vitest run` in `shared/diagram-renderer` (211 passed, including 2 new tests)
- [x] `npm run typecheck` — clean
- [x] `cargo test -p server` (55 passed) — bundle rebuild doesn't break anything
- [x] `cargo fmt --check` — clean
- [x] End-to-end verified via `spec42 diagrams export` against all of robot-vacuum's GeneralViews (table above)
- [x] Confirmed both new tests fail without their respective fix (not vacuous)

Fixes #23