### PR TITLE
Make interconnection-view SVG/JSON export deterministic (O-6)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Generated/vendored files that must stay byte-identical to what the tools that produce them
+# emit (ts-rs, esbuild), regardless of the checking-out platform's core.autocrlf setting.
+# Without this, a Windows checkout with autocrlf=true silently converts these LF-generated files
+# to CRLF, and typescript_bindings.rs's byte-for-byte comparison against a freshly regenerated
+# (LF) copy then fails on every run even though the content hasn't actually changed.
+vscode/src/generated/** text eol=lf
+crates/server/assets/** text eol=lf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **Fixed interconnection-view layout non-determinism** (O-6, tracked since 0.35.0's Known Issues below and [#22](https://github.com/elan8/spec42/issues/22)) — repeated `spec42 diagrams export` for the same unchanged model could produce different node coordinates each run. Root cause: `merge_ibd_payloads_inner` and `normalize_ibd_to_instance_paths` (`crates/sysml_model/src/semantic/ibd/{merge,instance_paths}.rs`) deduplicate parts/ports/connectors through a `HashMap`, then collect the deduped values straight into the output `Vec` via `.into_values()` — `HashMap`'s default hasher is randomly seeded per process, so that order (stable within one run) differed across separate CLI invocations, silently propagating into `finalize_merged_ibd_connectors`'s instance/def remap and from there into which of several structurally-equal-but-differently-worded connector representations survived dedup, and ultimately into ELK's node/edge order. Fixed by sorting every `HashMap`-derived collection by its DTO's own natural key right after collection, and switching `IbdDataDto.root_views` from `HashMap` to `BTreeMap` (it serializes directly to a JSON object, so its hash-randomized key order was a second, independent source of byte-level non-determinism). Verified byte-identical SVG output across repeated exports of both `examples/webshop` and the larger `sysml-robot-vacuum-cleaner` fixture; action-flow-view was independently re-verified deterministic on both fixtures too (the underlying `activity_graph.rs` extraction doesn't use the `HashMap`-to-`Vec` pattern that caused the interconnection-view bug). Remaining known non-determinism: `stats.modelBuildTimeMs` in the JSON payload is a real wall-clock measurement and legitimately varies run to run — structural (not byte) comparison is still required for that one field.
+
 - **Supports typed numeric analysis results and objective evaluation.** Analysis `return attribute`
   declarations are materialized with their type and expression, inherited by typed analysis usages,
   evaluated as numeric values rather than Boolean verdicts, and checked against typed objective
@@ -1006,7 +1008,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Known Issues
 
-- **Interconnection-view and action-flow-view layout is non-deterministic run-to-run** — re-exporting the same unchanged model can produce different node coordinates each time (same node/edge content). Byte-diff-based regression checking is unreliable for these 2 of 8 view kinds specifically; not a new issue in this release.
+- ~~**Interconnection-view and action-flow-view layout is non-deterministic run-to-run**~~ — fixed in `[Unreleased]`, see the O-6 entry above.
 - **Scoped/incremental IBD builds can resolve a different (but still valid) root than a full-workspace build** for some views in workspaces that use SysML variant-selection — a parity gap, not a correctness bug, but scoped and full-workspace exports of the same view can disagree.
 
 ## [0.34.0] - 2026-06-30

--- a/crates/lsp_server/src/views/visualization.rs
+++ b/crates/lsp_server/src/views/visualization.rs
@@ -175,7 +175,7 @@ pub(crate) fn build_sysml_visualization_response(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::{HashMap, HashSet};
+    use std::collections::{BTreeMap, HashMap, HashSet};
     use std::path::PathBuf;
     use std::time::Instant;
 
@@ -262,7 +262,7 @@ mod tests {
             package_container_groups: Vec::new(),
             root_candidates: Vec::new(),
             default_root: None,
-            root_views: HashMap::new(),
+            root_views: BTreeMap::new(),
             def_instance_mappings: Vec::new(),
         };
         let selected_ids: HashSet<String> = HashSet::from([
@@ -518,7 +518,7 @@ mod tests {
             package_container_groups: Vec::new(),
             root_candidates: vec!["Vehicle".to_string()],
             default_root: Some("Vehicle".to_string()),
-            root_views: HashMap::from([(
+            root_views: BTreeMap::from([(
                 "Vehicle".to_string(),
                 IbdRootViewDto {
                     parts: vec![IbdPartDto {

--- a/crates/sysml_model/src/semantic/ibd/dto.rs
+++ b/crates/sysml_model/src/semantic/ibd/dto.rs
@@ -1,7 +1,7 @@
 //! IBD DTO types shared across extraction, merge, and visualization.
 
 use serde::Serialize;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use ts_rs::TS;
 
 use crate::semantic::dto::RangeDto;
@@ -135,7 +135,10 @@ pub struct IbdDataDto {
     pub package_container_groups: Vec<IbdPackageContainerGroupDto>,
     pub root_candidates: Vec<String>,
     pub default_root: Option<String>,
-    pub root_views: HashMap<String, IbdRootViewDto>,
+    // O-6: `BTreeMap`, not `HashMap` -- this serializes directly to a JSON object, and a HashMap's
+    // hash-randomized iteration order would leak into that object's key order, varying run to run
+    // for byte-identical input even though the content is the same.
+    pub root_views: BTreeMap<String, IbdRootViewDto>,
 }
 
 #[derive(Debug, Clone, Serialize, TS)]

--- a/crates/sysml_model/src/semantic/ibd/extract_impl.rs
+++ b/crates/sysml_model/src/semantic/ibd/extract_impl.rs
@@ -531,8 +531,8 @@ pub fn build_ibd_for_uri(graph: &SemanticGraph, uri: &Url) -> IbdDataDto {
         .map(|(p, _, _, _)| p.name.clone())
         .collect();
     let default_root = root_candidates.first().cloned();
-    let mut root_views: std::collections::HashMap<String, IbdRootViewDto> =
-        std::collections::HashMap::new();
+    let mut root_views: std::collections::BTreeMap<String, IbdRootViewDto> =
+        std::collections::BTreeMap::new();
     for (p, _, _, _) in &roots_with_metrics {
         let root_prefix = p.qualified_name.as_str();
         let focused_connectors: Vec<IbdConnectorDto> = connectors

--- a/crates/sysml_model/src/semantic/ibd/extract_impl/tests.rs
+++ b/crates/sysml_model/src/semantic/ibd/extract_impl/tests.rs
@@ -399,7 +399,7 @@ fn normalize_ibd_remaps_non_regional_architecture_ports_to_instance_paths() {
             package_container_groups: Vec::new(),
             root_candidates: Vec::new(),
             default_root: None,
-            root_views: std::collections::HashMap::new(),
+            root_views: std::collections::BTreeMap::new(),
             // In production this is always populated by `build_instance_def_mappings` from real
             // typing edges (see `ibd/connectors.rs`); this hand-built fixture supplies the
             // equivalent mapping directly since it doesn't go through `build_ibd_for_uri`.

--- a/crates/sysml_model/src/semantic/ibd/instance_paths.rs
+++ b/crates/sysml_model/src/semantic/ibd/instance_paths.rs
@@ -80,7 +80,10 @@ pub fn normalize_ibd_to_instance_paths(ibd: &mut IbdDataDto) {
         }
         parts_by_qn.insert(part.qualified_name.clone(), part);
     }
+    // O-6: `.into_values()` yields entries in the HashMap's hash-randomized bucket order --
+    // re-sort by the DTO's own natural key so this doesn't undo merge.rs's determinism fix.
     ibd.parts = parts_by_qn.into_values().collect();
+    ibd.parts.sort_by(|a, b| a.id.cmp(&b.id));
 
     let mut ports_by_id: std::collections::HashMap<String, IbdPortDto> =
         std::collections::HashMap::new();
@@ -91,6 +94,8 @@ pub fn normalize_ibd_to_instance_paths(ibd: &mut IbdDataDto) {
         ports_by_id.insert(port.port_id.clone(), port);
     }
     ibd.ports = ports_by_id.into_values().collect();
+    ibd.ports
+        .sort_by(|a, b| (&a.parent_id, &a.name).cmp(&(&b.parent_id, &b.name)));
 
     for group in &mut ibd.container_groups {
         group.member_part_ids = group
@@ -109,7 +114,7 @@ pub fn normalize_ibd_to_instance_paths(ibd: &mut IbdDataDto) {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::collections::{BTreeMap, HashMap};
 
     use super::normalize_ibd_to_instance_paths;
     use crate::semantic::ibd::{
@@ -161,7 +166,7 @@ mod tests {
             container_groups: Vec::new(),
             package_container_groups: Vec::new(),
             root_candidates: Vec::new(),
-            root_views: HashMap::new(),
+            root_views: BTreeMap::new(),
             default_root: None,
             def_instance_mappings: vec![
                 DefInstanceMappingDto {
@@ -179,5 +184,95 @@ mod tests {
 
         assert_eq!(ibd.parts[0].qualified_name, architecture_part);
         assert_eq!(ibd.ports[0].parent_id, architecture_part);
+    }
+
+    fn part_with_id(qualified_name: &str) -> IbdPartDto {
+        IbdPartDto {
+            id: qualified_name.replace('.', "::"),
+            node_id: qualified_name.to_string(),
+            name: qualified_name
+                .rsplit('.')
+                .next()
+                .unwrap_or(qualified_name)
+                .to_string(),
+            qualified_name: qualified_name.to_string(),
+            uri: None,
+            container_id: None,
+            element_type: "part".to_string(),
+            attributes: HashMap::new(),
+            range: None,
+        }
+    }
+
+    fn port_with_parent(qualified_parent: &str, name: &str) -> IbdPortDto {
+        IbdPortDto {
+            id: format!("{qualified_parent}.{name}").replace('.', "::"),
+            port_id: format!("{qualified_parent}.{name}"),
+            name: name.to_string(),
+            parent_id: qualified_parent.to_string(),
+            direction: None,
+            port_type: None,
+            multiplicity: None,
+            port_side: None,
+            uri: None,
+            range: None,
+        }
+    }
+
+    /// O-6 regression: like `merge_ibd_payloads_inner`, `normalize_ibd_to_instance_paths` dedups
+    /// remapped parts/ports through a `HashMap` before collecting into the final `Vec`s
+    /// (`parts_by_qn.into_values()`/`ports_by_id.into_values()`), which would otherwise leak that
+    /// HashMap's hash-randomized bucket order into the output. Asserts the actual fix -- sorted
+    /// output -- rather than trying to reproduce cross-process hash randomization (which a
+    /// same-process test structurally cannot do; see the equivalent comment on
+    /// `merge_output_is_sorted_by_natural_key_regardless_of_input_order` in `merge.rs`).
+    #[test]
+    fn normalized_parts_and_ports_are_sorted_by_natural_key() {
+        let definition_root = "Architecture.Widget";
+        let instance_root = "Context.system.widget";
+        let mut ibd = IbdDataDto {
+            parts: vec![
+                part_with_id(&format!("{definition_root}.zebra")),
+                part_with_id(&format!("{definition_root}.apple")),
+                part_with_id(&format!("{definition_root}.mango")),
+            ],
+            ports: vec![
+                port_with_parent(&format!("{definition_root}.zebra"), "out"),
+                port_with_parent(&format!("{definition_root}.apple"), "out"),
+            ],
+            connectors: Vec::new(),
+            container_groups: Vec::new(),
+            package_container_groups: Vec::new(),
+            root_candidates: Vec::new(),
+            root_views: BTreeMap::new(),
+            default_root: None,
+            def_instance_mappings: vec![DefInstanceMappingDto {
+                def_root: definition_root.to_string(),
+                instance_root: instance_root.to_string(),
+            }],
+        };
+
+        normalize_ibd_to_instance_paths(&mut ibd);
+
+        let part_names: Vec<String> = ibd.parts.iter().map(|p| p.qualified_name.clone()).collect();
+        assert_eq!(
+            part_names,
+            vec![
+                format!("{instance_root}.apple"),
+                format!("{instance_root}.mango"),
+                format!("{instance_root}.zebra"),
+            ],
+            "remapped parts must be sorted by qualified_name (id)"
+        );
+
+        let port_parents: Vec<String> = ibd.ports.iter().map(|p| p.parent_id.clone()).collect();
+        assert_eq!(
+            port_parents,
+            vec![
+                format!("{instance_root}.apple"),
+                format!("{instance_root}.zebra"),
+            ],
+            "remapped ports must be sorted by (parent_id, name)"
+        );
     }
 }

--- a/crates/sysml_model/src/semantic/ibd/merge.rs
+++ b/crates/sysml_model/src/semantic/ibd/merge.rs
@@ -45,8 +45,8 @@ fn merge_ibd_payloads_inner(ibds: Vec<IbdDataDto>, enrich_connectors: bool) -> I
         IbdConnectorDto,
     > = std::collections::HashMap::new();
     let mut root_candidates: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
-    let mut root_views: std::collections::HashMap<String, IbdRootViewDto> =
-        std::collections::HashMap::new();
+    let mut root_views: std::collections::BTreeMap<String, IbdRootViewDto> =
+        std::collections::BTreeMap::new();
     let mut container_groups_by_id: std::collections::HashMap<String, IbdContainerGroupDto> =
         std::collections::HashMap::new();
     let mut package_container_groups_by_id: std::collections::HashMap<
@@ -156,9 +156,24 @@ fn merge_ibd_payloads_inner(ibds: Vec<IbdDataDto>, enrich_connectors: bool) -> I
         }
     }
 
-    let parts: Vec<IbdPartDto> = parts_by_id.into_values().collect();
-    let ports: Vec<IbdPortDto> = ports_by_key.into_values().collect();
-    let connectors: Vec<IbdConnectorDto> = connectors_by_key.into_values().collect();
+    // O-6: `.into_values()` on a `HashMap` yields entries in that map's internal bucket order,
+    // which depends on Rust's per-process-randomized default hasher -- stable within one run, but
+    // different across separate `spec42 diagrams export` invocations even for byte-identical
+    // input. That randomized order silently propagates into `finalize_merged_ibd_connectors`'s
+    // instance/def remap (which iterates `parts`/`connectors` to build its mapping list) and from
+    // there into which of several structurally-equal-but-differently-worded connector
+    // representations survives dedup, and ultimately into ELK's node/edge order -- producing
+    // different (but individually valid) layouts run to run for the same model. Sorting by each
+    // DTO's own natural key right after the HashMap collapses back to deterministic id/name order
+    // regardless of hash seed.
+    let mut parts: Vec<IbdPartDto> = parts_by_id.into_values().collect();
+    parts.sort_by(|a, b| a.id.cmp(&b.id));
+    let mut ports: Vec<IbdPortDto> = ports_by_key.into_values().collect();
+    ports.sort_by(|a, b| (&a.parent_id, &a.name).cmp(&(&b.parent_id, &b.name)));
+    let mut connectors: Vec<IbdConnectorDto> = connectors_by_key.into_values().collect();
+    connectors.sort_by(|a, b| {
+        (&a.source_id, &a.target_id, &a.rel_type).cmp(&(&b.source_id, &b.target_id, &b.rel_type))
+    });
     let (parts, ports, connectors) =
         prune_interconnection_definition_parts(parts, ports, connectors);
     let mut connectors = connectors;
@@ -166,6 +181,16 @@ fn merge_ibd_payloads_inner(ibds: Vec<IbdDataDto>, enrich_connectors: bool) -> I
         enrich_connector_endpoint_refs(&mut connectors, &parts, &ports);
     }
     for view in root_views.values_mut() {
+        view.parts.sort_by(|a, b| a.id.cmp(&b.id));
+        view.ports
+            .sort_by(|a, b| (&a.parent_id, &a.name).cmp(&(&b.parent_id, &b.name)));
+        view.connectors.sort_by(|a, b| {
+            (&a.source_id, &a.target_id, &a.rel_type).cmp(&(
+                &b.source_id,
+                &b.target_id,
+                &b.rel_type,
+            ))
+        });
         let (view_parts, view_ports, view_connectors) = prune_interconnection_definition_parts(
             std::mem::take(&mut view.parts),
             std::mem::take(&mut view.ports),
@@ -198,15 +223,160 @@ fn merge_ibd_payloads_inner(ibds: Vec<IbdDataDto>, enrich_connectors: bool) -> I
         })
         .cloned();
 
+    let mut container_groups: Vec<IbdContainerGroupDto> =
+        container_groups_by_id.into_values().collect();
+    container_groups.sort_by(|a, b| a.id.cmp(&b.id));
+    let mut package_container_groups: Vec<IbdPackageContainerGroupDto> =
+        package_container_groups_by_id.into_values().collect();
+    package_container_groups.sort_by(|a, b| a.id.cmp(&b.id));
+    let mut def_instance_mappings: Vec<DefInstanceMappingDto> =
+        def_instance_mappings_by_key.into_values().collect();
+    def_instance_mappings
+        .sort_by(|a, b| (&a.def_root, &a.instance_root).cmp(&(&b.def_root, &b.instance_root)));
+
     IbdDataDto {
         parts,
         ports,
         connectors,
-        container_groups: container_groups_by_id.into_values().collect(),
-        package_container_groups: package_container_groups_by_id.into_values().collect(),
+        container_groups,
+        package_container_groups,
         root_candidates: root_candidates.into_iter().collect(),
         default_root,
         root_views,
-        def_instance_mappings: def_instance_mappings_by_key.into_values().collect(),
+        def_instance_mappings,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn part(id: &str) -> IbdPartDto {
+        IbdPartDto {
+            id: id.to_string(),
+            node_id: id.replace("::", "."),
+            name: id.rsplit("::").next().unwrap_or(id).to_string(),
+            qualified_name: id.replace("::", "."),
+            uri: None,
+            container_id: None,
+            element_type: "part".to_string(),
+            attributes: HashMap::new(),
+            range: None,
+        }
+    }
+
+    /// `prune_interconnection_definition_parts` matches `port.parent_id` against the owning
+    /// part's `qualified_name` verbatim (no `::`/`.` normalization at that step, unlike connector
+    /// endpoint resolution) -- so `parent` must be the *part's own* `qualified_name`, not its `id`.
+    fn port(parent: &IbdPartDto, name: &str) -> IbdPortDto {
+        IbdPortDto {
+            id: format!("{}::{name}", parent.id),
+            port_id: format!("{}.{name}", parent.qualified_name),
+            name: name.to_string(),
+            parent_id: parent.qualified_name.clone(),
+            direction: None,
+            port_type: None,
+            multiplicity: None,
+            port_side: None,
+            uri: None,
+            range: None,
+        }
+    }
+
+    fn connector(source_id: &str, target_id: &str) -> IbdConnectorDto {
+        IbdConnectorDto {
+            source: source_id.to_string(),
+            target: target_id.to_string(),
+            source_id: source_id.to_string(),
+            target_id: target_id.to_string(),
+            source_part_id: None,
+            target_part_id: None,
+            source_port_id: None,
+            target_port_id: None,
+            rel_type: "connection".to_string(),
+        }
+    }
+
+    fn ibd(
+        parts: Vec<IbdPartDto>,
+        ports: Vec<IbdPortDto>,
+        connectors: Vec<IbdConnectorDto>,
+    ) -> IbdDataDto {
+        IbdDataDto {
+            parts,
+            ports,
+            connectors,
+            def_instance_mappings: Vec::new(),
+            container_groups: Vec::new(),
+            package_container_groups: Vec::new(),
+            root_candidates: Vec::new(),
+            default_root: None,
+            root_views: Default::default(),
+        }
+    }
+
+    /// O-6 regression: `merge_ibd_payloads_inner` dedups parts/ports/connectors through a
+    /// `HashMap` before collecting them into the final `Vec`s. `HashMap`'s default hasher is
+    /// randomly seeded per process, so `.into_values().collect()` alone yields a different (but
+    /// content-equal) order every time the *process* is restarted -- invisible to a same-process
+    /// test that merges once and asserts a single result, since the seed (and therefore the
+    /// order) is identical across calls within one process. What a same-process test *can* pin
+    /// down is the actual fix: the merge output must be sorted by each DTO's own natural key,
+    /// regardless of which order (or how many duplicate/overlapping per-URI payloads) fed into
+    /// it. Feeds the per-URI payloads in deliberately reversed/interleaved order relative to the
+    /// expected sorted output to make sure a sort is actually happening, not just coincidentally
+    /// already-ordered input.
+    #[test]
+    fn merge_output_is_sorted_by_natural_key_regardless_of_input_order() {
+        let part_a = part("Pkg::A");
+        let part_b = part("Pkg::B");
+        let part_c = part("Pkg::C");
+        let port_a_in = port(&part_a, "in");
+        let port_b_mid = port(&part_b, "mid");
+        let port_c_out = port(&part_c, "out");
+
+        let ibd_c = ibd(
+            vec![part_c.clone()],
+            vec![port_c_out.clone()],
+            vec![connector(&port_c_out.port_id, &port_a_in.port_id)],
+        );
+        let ibd_a = ibd(
+            vec![part_a.clone(), part_a.clone()], // duplicate part across "documents"
+            vec![port_a_in.clone()],
+            vec![],
+        );
+        let ibd_b = ibd(vec![part_b.clone()], vec![port_b_mid.clone()], vec![]);
+
+        let merged = merge_ibd_payloads_for_workspace_finalize(vec![ibd_c, ibd_a, ibd_b]);
+
+        let part_ids: Vec<&str> = merged.parts.iter().map(|p| p.id.as_str()).collect();
+        assert_eq!(
+            part_ids,
+            vec!["Pkg::A", "Pkg::B", "Pkg::C"],
+            "parts must be sorted by id"
+        );
+
+        let port_keys: Vec<(&str, &str)> = merged
+            .ports
+            .iter()
+            .map(|p| (p.parent_id.as_str(), p.name.as_str()))
+            .collect();
+        assert_eq!(
+            port_keys,
+            vec![("Pkg.A", "in"), ("Pkg.B", "mid"), ("Pkg.C", "out")],
+            "ports must be sorted by (parent_id, name)"
+        );
+
+        let connector_keys: Vec<(&str, &str)> = merged
+            .connectors
+            .iter()
+            .map(|c| (c.source_id.as_str(), c.target_id.as_str()))
+            .collect();
+        assert_eq!(
+            connector_keys,
+            vec![(port_c_out.port_id.as_str(), port_a_in.port_id.as_str())],
+            "connectors must be sorted by (source_id, target_id, rel_type)"
+        );
     }
 }

--- a/crates/sysml_model/src/semantic/interconnection_scene.rs
+++ b/crates/sysml_model/src/semantic/interconnection_scene.rs
@@ -383,7 +383,7 @@ pub fn build_interconnection_scene(
 mod tests {
     use super::*;
     use crate::semantic::ibd::{IbdConnectorDto, IbdPartDto};
-    use std::collections::HashMap;
+    use std::collections::{BTreeMap, HashMap};
 
     fn test_part(name: &str, qn: &str, container: Option<&str>) -> IbdPartDto {
         IbdPartDto {
@@ -453,7 +453,7 @@ mod tests {
             package_container_groups: Vec::new(),
             root_candidates: vec!["Grid.northSouthRing".to_string()],
             default_root: None,
-            root_views: HashMap::new(),
+            root_views: BTreeMap::new(),
             def_instance_mappings: Vec::new(),
         };
 
@@ -507,7 +507,7 @@ mod tests {
             package_container_groups: Vec::new(),
             root_candidates: vec!["Grid.mainElectronics".to_string()],
             default_root: None,
-            root_views: HashMap::new(),
+            root_views: BTreeMap::new(),
             def_instance_mappings: Vec::new(),
         };
 
@@ -580,7 +580,7 @@ mod tests {
             }],
             root_candidates: vec!["PhysicalArchitecture.AutonomousFloorCleaningRobot".to_string()],
             default_root: None,
-            root_views: HashMap::new(),
+            root_views: BTreeMap::new(),
             def_instance_mappings: Vec::new(),
         };
 

--- a/crates/sysml_model/src/semantic/prepared_view/preparers/interconnection.rs
+++ b/crates/sysml_model/src/semantic/prepared_view/preparers/interconnection.rs
@@ -201,7 +201,7 @@ pub fn prepare_interconnection_scene(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::collections::{BTreeMap, HashMap};
 
     use crate::semantic::dto::{PositionDto, RangeDto, SysmlVisualizationResultDto};
     use crate::semantic::ibd::{IbdDataDto, IbdPartDto, IbdPortDto};
@@ -280,7 +280,7 @@ mod tests {
             package_container_groups: Vec::new(),
             root_candidates: vec!["Grid.mainElectronics".to_string()],
             default_root: None,
-            root_views: HashMap::new(),
+            root_views: BTreeMap::new(),
             def_instance_mappings: Vec::new(),
         };
         let scene = build_interconnection_scene(

--- a/crates/sysml_model/src/semantic/visualization/ibd_scope.rs
+++ b/crates/sysml_model/src/semantic/visualization/ibd_scope.rs
@@ -1,6 +1,6 @@
 //! IBD scoping and filtering for interconnection visualization.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashSet};
 
 use crate::semantic::ibd::{IbdDataDto, IbdRootViewDto};
 
@@ -81,7 +81,7 @@ pub fn filter_ibd_by_visible_ids(ibd: &IbdDataDto, visible_ids: &HashSet<String>
         })
         .cloned()
         .collect();
-    let mut root_views = HashMap::new();
+    let mut root_views = BTreeMap::new();
     for (name, view) in &ibd.root_views {
         let filtered_parts: Vec<_> = view
             .parts
@@ -338,7 +338,7 @@ pub(crate) fn filter_ibd_by_root_prefixes(
         .cloned()
         .collect();
 
-    let mut root_views = HashMap::new();
+    let mut root_views = BTreeMap::new();
     for (name, view) in &ibd.root_views {
         let filtered_parts: Vec<_> = view
             .parts
@@ -496,7 +496,7 @@ pub fn select_interconnection_ibd_scope_with_trace(
             package_container_groups: Vec::new(),
             root_candidates: Vec::new(),
             default_root: None,
-            root_views: HashMap::new(),
+            root_views: BTreeMap::new(),
             def_instance_mappings: Vec::new(),
         };
         let trace_result = trace(label, &visible_scope_ibd, &empty);
@@ -563,6 +563,7 @@ pub fn select_interconnection_ibd_scope(
 mod interconnection_scope_tests {
     use super::*;
     use crate::semantic::ibd::{IbdConnectorDto, IbdDataDto, IbdPartDto};
+    use std::collections::HashMap;
 
     fn sample_ibd() -> IbdDataDto {
         IbdDataDto {
@@ -593,7 +594,7 @@ mod interconnection_scope_tests {
             package_container_groups: Vec::new(),
             root_candidates: Vec::new(),
             default_root: None,
-            root_views: HashMap::new(),
+            root_views: BTreeMap::new(),
             def_instance_mappings: Vec::new(),
         }
     }

--- a/crates/sysml_model/src/semantic/visualization/response.rs
+++ b/crates/sysml_model/src/semantic/visualization/response.rs
@@ -1,6 +1,6 @@
 //! Visualization response assembly (artifacts, slim payload, DTO output).
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::time::Instant;
 
 use url::Url;
@@ -130,7 +130,7 @@ pub fn build_merged_workspace_ibd(
             package_container_groups: Vec::new(),
             root_candidates: Vec::new(),
             default_root: None,
-            root_views: HashMap::new(),
+            root_views: BTreeMap::new(),
             def_instance_mappings: Vec::new(),
         };
     }
@@ -172,7 +172,7 @@ pub fn empty_merged_ibd() -> IbdDataDto {
         package_container_groups: Vec::new(),
         root_candidates: Vec::new(),
         default_root: None,
-        root_views: HashMap::new(),
+        root_views: BTreeMap::new(),
         def_instance_mappings: Vec::new(),
     }
 }


### PR DESCRIPTION
## Summary

Repeated `spec42 diagrams export` for interconnection-view could produce different node coordinates and part/port/connector orderings run to run, even for byte-identical input (documented as a known issue since 0.35.0).

**Root cause**: `merge_ibd_payloads_inner` (`ibd/merge.rs`) and `normalize_ibd_to_instance_paths` (`ibd/instance_paths.rs`) deduplicate parts/ports/connectors through a `HashMap` keyed by natural identity, then collect straight into the output `Vec` via `.into_values()`. `HashMap`'s default hasher is randomly seeded **per process** — stable within one run, but different across separate CLI invocations. That randomized order silently propagates into `finalize_merged_ibd_connectors`'s workspace-wide instance/def remap, and from there into **which of several structurally-equal-but-differently-worded connector representations** (e.g. a definition-nested path vs. a deeper real instance path) survives dedup's first-wins semantics — and ultimately into the node/edge order ELK lays out from.

**Fix**: sort every `HashMap`-derived collection (parts, ports, connectors, container groups, package container groups, def-instance mappings, and each root view's own copies) by its DTO's own natural key immediately after collection, in both files. Also switched `IbdDataDto.root_views` from `HashMap` to `BTreeMap` — it serializes directly to a JSON object, so its hash-randomized key order was a second, independent source of byte-level non-determinism in the JSON export path (invisible in rendered SVG, which never iterates `root_views`).

**Verification**: byte-identical SVG output across repeated exports of both `examples/webshop` and the larger `sysml-robot-vacuum-cleaner` fixture, for both interconnection-view and action-flow-view. Action-flow-view was independently re-verified deterministic on both fixtures — the underlying `activity_graph.rs` extraction doesn't use the `HashMap`-to-`Vec`-via-`into_values()` pattern that caused the bug, and was already deterministic before this change (confirmed against unmodified `main`).

**Remaining known non-determinism** (documented in `CHANGELOG.md`): `stats.modelBuildTimeMs` in the JSON payload is a real wall-clock measurement and legitimately varies run to run — structural (not byte) comparison is still required for that one field.

**Bonus fix**: also fixed the recurring `typescript_bindings.rs` CRLF/LF false failure seen across several recent PRs in this repo. There was no `.gitattributes`, so a Windows checkout with `core.autocrlf=true` silently converted the committed (LF) ts-rs-generated bindings and vendored JS assets to CRLF on disk, while the test's fresh ts-rs re-export always emits LF and compares byte-for-byte. Added `.gitattributes` pinning `vscode/src/generated/**` and `crates/server/assets/**` to `eol=lf`, and re-normalized the working tree to match.

## Changes
- `crates/sysml_model/src/semantic/ibd/merge.rs` — sort after every `.into_values()`, plus a regression test.
- `crates/sysml_model/src/semantic/ibd/instance_paths.rs` — same, plus a regression test.
- `crates/sysml_model/src/semantic/ibd/dto.rs` + call sites (`extract_impl.rs`, `interconnection_scene.rs`, `prepared_view/preparers/interconnection.rs`, `visualization/ibd_scope.rs`, `visualization/response.rs`) — `root_views: HashMap` → `BTreeMap`.
- `.gitattributes` — new, pins generated/vendored files to `eol=lf`.
- `CHANGELOG.md` — new entry, closes the 0.35.0 Known Issues note.

## Test plan
- [x] `cargo test -p sysml_model` — all pass (261 total across suites), including 2 new regression tests
- [x] Both new tests verified to fail without their corresponding fix
- [x] `cargo test -p server` (55 passed)
- [x] `cargo fmt --check`, `cargo check --workspace` — clean
- [x] Manual repro: `spec42 diagrams export examples/webshop --selected-view connections --format svg` × 3 → identical MD5 (was 3 different hashes before the fix)
- [x] Same for `checkoutPipeline` (action-flow-view) and the larger robot-vacuum `interconnections`/`cliffSafeStopScenario` views
- [x] `typescript_bindings.rs` now passes cleanly (previously a known pre-existing CRLF failure, confirmed across issues #20/#21/#23/#24's PRs)

Fixes #22