### PR TITLE
chore(deps): bump sysml-v2-parser 0.53.0 -> 0.54.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **Bumped `sysml-v2-parser` 0.53.0 → 0.54.0** ([#18](https://github.com/elan8/spec42/issues/18)) —
+  pulls in #70 (`parse()`/`parse_for_editor()` equivalence), the #78 follow-up (full-library
+  strict-diagnostics gaps: `in`/`ref`/`calc` redefinition forms, nested `calc def`, `abstract
+  calc`), and #85 (connector-end/interface/flow shorthand gaps). `PARSE_AST_VERSION` moved 70 → 71
+  for this release's AST-shape changes, which broke exhaustive matches across `sysml_model` and
+  `sysml_tokens`: new `InOutDecl.is_redefinition`, `CalcDefBodyElement::{CalcUsage,CalcDef,
+  PartUsage}`, `ConstraintDefBodyElement::{Constraint,AttributeUsage}`,
+  `RequirementDefBodyElement::{SubjectRef,VariantUsage,Constraint}`,
+  `StateDefBodyElement::InOutDecl`, `OccurrenceBodyElement::EndDecl`,
+  `InterfaceDefBodyElement::FlowUsage`, `InterfaceUsageBodyElement::EndDecl`,
+  `InterfaceUsage::TypedConnect.name`, `EndDecl.crosses`, `UseCaseDefBodyElement::{ActionUsage,
+  AnalysisCaseUsage,CalcUsage,AttributeUsage,RequirementUsage,PartUsage,Expression}`, and
+  `Expression::{Conditional,Extent}`. Each new variant got real graph-builder/semantic-token
+  handling (not stub catch-alls) by mirroring the closest existing sibling variant's
+  materialization, reusing shared helpers where one already existed (`materialize_part_usage`,
+  `materialize_attribute_usage`, `materialize_requirement_usage`,
+  `materialize_top_level_action_usage`, `materialize_analysis_case_usage`, `collect_semantic_
+  ranges_ref_decl`) and factoring two new ones where duplication would otherwise have tripled
+  (`calc_constraint_def::{build_calc_def_body_elements,materialize_calc_usage}`, now shared by
+  `part_def.rs`'s top-level `calc` usage arm, this module's own nested-calc-in-calc rollups, and
+  analysis/verification case bodies' nested `calc` usages). Also fixed two independent breaking
+  changes from the same bump: `RefBody::Brace`'s `elements` are now `RefBodyElement`-wrapped
+  (`action.rs`'s `add_ref_decl` now filters to the `Action(..)` variant before recursing), and
+  `CaseReturnDecl.value_expression` was renamed/retyped to `value: Option<Node<FeatureValue>>`
+  (`analysis_case.rs` now unwraps `.value.expression`). A few genuinely new constructs
+  (`RequirementDefBodyElement::Expression`'s bare analysis-case result expression,
+  `AssertConstraint` in the newly-reachable body contexts) were left as documented no-ops rather
+  than guessed at, matching this codebase's existing "not yet modeled" precedent for the same
+  constructs elsewhere. Full workspace (`cargo test --workspace`, 130 suites) green; `cargo fmt`,
+  `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo doc --no-deps --workspace`
+  all clean. This is a partial step on #18, not a 1.0 pin confirmation -- the OMG-library-baseline
+  and roadmap-documentation acceptance criteria are still open.
+
 - **Removed the MCP server and read-only HTTP API** ([#51](https://github.com/elan8/spec42/issues/51)) —
   `spec42-mcp` (stdio MCP server) and `spec42 api serve` (read-only HTTP API, `docs/api/`) are gone.
   Investigation found no AI host actually depended on either surface: VS Code Language Model Tools

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1505,9 +1505,9 @@ dependencies = [
 
 [[package]]
 name = "sysml-v2-parser"
-version = "0.53.0"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7151ec3dde21566673afeebb0d7fe29524d5bc77538ae1897e020a3796400f4e"
+checksum = "5db89688b6bab9dacbf8150e3f32f636decd36e34fcb8aaacbdb52fe281a9134"
 dependencies = [
  "log",
  "nom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,5 +29,5 @@ serde_json = "1"
 thiserror = "2"
 clap = { version = "4", features = ["derive"] }
 petgraph = { version = "0.8", features = ["serde-1"] }
-sysml-v2-parser = { version = "0.53.0", features = ["serde"] }
+sysml-v2-parser = { version = "0.54.0", features = ["serde"] }
 ts-rs = { version = "11", features = ["serde-compat", "serde-json-impl"] }

--- a/crates/sysml_model/src/semantic/ast_util.rs
+++ b/crates/sysml_model/src/semantic/ast_util.rs
@@ -513,6 +513,14 @@ impl ExpressionAlgebra for DeclaredExpressionAlgebra {
                 expression.reference = Some(type_name.clone());
                 expression.children = subs;
             }
+            Expr::Conditional { .. } => {
+                expression.kind = "conditional".into();
+                expression.children = subs;
+            }
+            Expr::Extent { target } => {
+                expression.kind = "extent".into();
+                expression.reference = Some(target.clone());
+            }
         }
         expression
     }

--- a/crates/sysml_model/src/semantic/expression_fold.rs
+++ b/crates/sysml_model/src/semantic/expression_fold.rs
@@ -105,6 +105,17 @@ pub(crate) fn expression_children(node: &Node<Expression>) -> Vec<ExpressionChil
             }));
             children
         }
+        Expression::Conditional {
+            test,
+            then_expr,
+            else_expr,
+        } => vec![
+            ExpressionChild::Sub(test),
+            ExpressionChild::Sub(then_expr),
+            ExpressionChild::Sub(else_expr),
+        ],
+        // `target` is a plain qualified-name string (`all QualifiedName`), not a sub-expression.
+        Expression::Extent { .. } => Vec::new(),
     }
 }
 

--- a/crates/sysml_model/src/semantic/extracted_model.rs
+++ b/crates/sysml_model/src/semantic/extracted_model.rs
@@ -157,6 +157,10 @@ impl ExpressionAlgebra for ExprToStringAlgebra {
             }
             Expression::MetadataAccess(_) => format!("{}.metadata", subs[0]),
             Expression::Null => String::new(),
+            Expression::Conditional { .. } => {
+                format!("if {} ? {} else {}", subs[0], subs[1], subs[2])
+            }
+            Expression::Extent { target } => format!("all {target}"),
         }
     }
 }

--- a/crates/sysml_model/src/semantic/graph_builder/action.rs
+++ b/crates/sysml_model/src/semantic/graph_builder/action.rs
@@ -288,8 +288,18 @@ fn add_ref_decl(
         super::ref_decl::RefDeclOptions::default(),
     );
     if let RefBody::Brace { elements } = &wrap.value.body {
-        if !elements.is_empty() {
-            build_from_action_def_body(elements, uri, container_prefix, &ref_node_id, g);
+        // `RefBody::Brace` elements are `RefBodyElement`-wrapped (shared across action/part/state
+        // ref-body contexts); this caller only recurses the action-shaped ones, since
+        // `build_from_action_def_body` graph-builds `ActionDefBodyElement` content specifically.
+        let action_elements: Vec<sysml_v2_parser::Node<ActionDefBodyElement>> = elements
+            .iter()
+            .filter_map(|el| match &el.value {
+                sysml_v2_parser::ast::RefBodyElement::Action(action_el) => Some(action_el.clone()),
+                _ => None,
+            })
+            .collect();
+        if !action_elements.is_empty() {
+            build_from_action_def_body(&action_elements, uri, container_prefix, &ref_node_id, g);
         }
     }
 }

--- a/crates/sysml_model/src/semantic/graph_builder/analysis_case.rs
+++ b/crates/sysml_model/src/semantic/graph_builder/analysis_case.rs
@@ -142,9 +142,9 @@ pub(super) fn build_from_analysis_body(
                     attrs.insert("returnType".to_string(), serde_json::json!(type_name));
                 }
                 let expression = value
-                    .value_expression
+                    .value
                     .as_ref()
-                    .map(expressions::expression_to_debug_string);
+                    .map(|v| expressions::expression_to_debug_string(&v.value.expression));
                 if let Some(expression) = expression.as_deref() {
                     attrs.insert("value".to_string(), serde_json::json!(expression));
                 }
@@ -338,7 +338,22 @@ pub(super) fn build_from_analysis_body(
             | UseCaseDefBodyElement::FirstSuccession(_)
             | UseCaseDefBodyElement::ThenUseCaseUsage(_)
             | UseCaseDefBodyElement::RefRedefinition(_)
-            | UseCaseDefBodyElement::SubjectRef(_) => {}
+            | UseCaseDefBodyElement::SubjectRef(_)
+            // Nested action/analysis/calc/attribute/requirement/part usages: already fully
+            // materialized by `wire_extended_case_body_element` above (which returns `true` and
+            // `continue`s before this match runs) -- these arms are unreachable, kept only for
+            // exhaustiveness.
+            | UseCaseDefBodyElement::ActionUsage(_)
+            | UseCaseDefBodyElement::AnalysisCaseUsage(_)
+            | UseCaseDefBodyElement::CalcUsage(_)
+            | UseCaseDefBodyElement::AttributeUsage(_)
+            | UseCaseDefBodyElement::RequirementUsage(_)
+            | UseCaseDefBodyElement::PartUsage(_) => {}
+            // Bare result expression (validation `10a`: `vehicle.mass`) -- not yet wired into
+            // `analysis_result_qualified`; needs a qualified-name resolution strategy for a raw
+            // expression (as opposed to `CaseReturnDecl`/`AttributeUsage`, which declare their
+            // own name). Not a regression: this content wasn't reachable AST at all before.
+            UseCaseDefBodyElement::Expression(_) => {}
             UseCaseDefBodyElement::Doc(doc) => {
                 super::attach_doc_comment(g, parent_id, &doc.value.text);
             }

--- a/crates/sysml_model/src/semantic/graph_builder/attribute_body.rs
+++ b/crates/sysml_model/src/semantic/graph_builder/attribute_body.rs
@@ -165,6 +165,33 @@ pub(super) fn build_from_attribute_body(
                     &mk_node.span,
                 );
             }
+            // Also shared with `item def`/`item` usage bodies: `ref`/`ref part` members
+            // (validation `15_11`/`15_19`/`17a`/`17b`). Same materialization interface_def.rs/
+            // action.rs already use for `ref` in their own body contexts.
+            AttributeBodyElement::RefDecl(ref_node) => {
+                super::ref_decl::materialize_ref_decl(
+                    g,
+                    uri,
+                    container_prefix,
+                    parent_id,
+                    ref_node,
+                    super::ref_decl::RefDeclOptions::default(),
+                );
+            }
+            // Nested `part` usage inside an item/attribute body (validation `3e`/`14c`).
+            AttributeBodyElement::PartUsage(part) => {
+                usage_builders::materialize_part_usage(
+                    part,
+                    uri,
+                    container_prefix,
+                    Some(parent_id),
+                    g,
+                );
+            }
+            // `assert constraint` here mirrors `part_def.rs`'s/`action.rs`'s existing
+            // `AssertConstraint(_) => {}` precedent -- no dedicated graph projection yet for any
+            // body kind except `occurrence_body.rs`'s.
+            AttributeBodyElement::AssertConstraint(_) => {}
             AttributeBodyElement::Error(_) | AttributeBodyElement::Other(_) => {}
         }
     }

--- a/crates/sysml_model/src/semantic/graph_builder/calc_constraint_def.rs
+++ b/crates/sysml_model/src/semantic/graph_builder/calc_constraint_def.rs
@@ -75,10 +75,14 @@ fn extract_constraint_metadata(
                         expression = Some(rendered);
                     }
                 }
+                // Nested constraint/attribute content isn't summarized here -- this function
+                // only extracts the flat params/expression pair for the `analysis*` attrs below.
                 ConstraintDefBodyElement::Error(_)
                 | ConstraintDefBodyElement::Doc(_)
                 | ConstraintDefBodyElement::MetadataAnnotation(_)
-                | ConstraintDefBodyElement::Other(_) => {}
+                | ConstraintDefBodyElement::Other(_)
+                | ConstraintDefBodyElement::Constraint(_)
+                | ConstraintDefBodyElement::AttributeUsage(_) => {}
             }
         }
     }
@@ -137,9 +141,14 @@ fn extract_calc_metadata(
                         expression = Some(rendered);
                     }
                 }
+                // Nested calc/part content isn't summarized here -- this function only extracts
+                // the flat params/return/expression triple for the `analysis*` attrs below.
                 CalcDefBodyElement::Error(_)
                 | CalcDefBodyElement::Doc(_)
-                | CalcDefBodyElement::MetadataAnnotation(_) => {}
+                | CalcDefBodyElement::MetadataAnnotation(_)
+                | CalcDefBodyElement::CalcUsage(_)
+                | CalcDefBodyElement::CalcDef(_)
+                | CalcDefBodyElement::PartUsage(_) => {}
             }
         }
     }
@@ -294,63 +303,134 @@ pub(super) fn build_calc_def(
         attrs,
         parent_id,
     );
-    // Wire InOutDecl / ReturnDecl as typed child graph nodes.
-    if let CalcDefBody::Brace { elements } = &c_node.value.body {
-        let calc_id = NodeId::new(uri, &qualified);
-        for element in elements {
-            match &element.value {
-                CalcDefBodyElement::InOutDecl(in_out) => {
-                    super::action::add_in_out_decl(g, uri, container_prefix, &calc_id, in_out);
-                }
-                CalcDefBodyElement::ReturnDecl(ret) => {
-                    let ret_qualified = qualified_name_for_node(
-                        g,
-                        uri,
-                        Some(calc_id.qualified_name.as_str()),
-                        &ret.value.name,
-                        "return parameter",
-                    );
-                    let mut ret_attrs = HashMap::new();
-                    ret_attrs.insert("direction".to_string(), serde_json::json!("return"));
-                    ret_attrs.insert(
-                        "parameterType".to_string(),
-                        serde_json::json!(&ret.value.type_name),
-                    );
-                    add_node_and_recurse(
-                        g,
-                        uri,
-                        &ret_qualified,
-                        "return parameter",
-                        ret.value.name.clone(),
-                        span_to_range(&ret.span),
-                        ret_attrs,
-                        Some(&calc_id),
-                    );
-                    add_typing_edge_if_exists(
-                        g,
-                        uri,
-                        &ret_qualified,
-                        &ret.value.type_name,
-                        container_prefix,
-                    );
-                }
-                CalcDefBodyElement::Doc(doc) => {
-                    super::attach_doc_comment(g, &calc_id, &doc.value.text);
-                }
-                CalcDefBodyElement::MetadataAnnotation(meta) => {
-                    super::metadata_def::add_metadata_annotation_node(
-                        g,
-                        uri,
-                        container_prefix,
-                        &calc_id,
-                        &meta.value,
-                        &meta.span,
-                    );
-                }
-                CalcDefBodyElement::Expression(_)
-                | CalcDefBodyElement::Other(_)
-                | CalcDefBodyElement::Error(_) => {}
+    let calc_id = NodeId::new(uri, &qualified);
+    build_calc_def_body_elements(g, uri, container_prefix, &calc_id, &c_node.value.body);
+}
+
+/// Shared child-element walker for a `calc`/`calc def`'s own body: `in`/`out`/`return`
+/// parameters, doc/metadata annotations, nested `part`/`calc`/`calc def` content. Used by both
+/// [`build_calc_def`] (top-level `calc def`) and `part_def.rs`'s `PDBE::CalcUsage` arm (a `calc`
+/// usage nested inside a `part def` body) so the two don't hand-roll the same loop twice.
+pub(super) fn build_calc_def_body_elements(
+    g: &mut SemanticGraph,
+    uri: &Url,
+    container_prefix: Option<&str>,
+    calc_id: &NodeId,
+    body: &CalcDefBody,
+) {
+    let CalcDefBody::Brace { elements } = body else {
+        return;
+    };
+    for element in elements {
+        match &element.value {
+            CalcDefBodyElement::InOutDecl(in_out) => {
+                super::action::add_in_out_decl(g, uri, container_prefix, calc_id, in_out);
             }
+            CalcDefBodyElement::ReturnDecl(ret) => {
+                let ret_qualified = qualified_name_for_node(
+                    g,
+                    uri,
+                    Some(calc_id.qualified_name.as_str()),
+                    &ret.value.name,
+                    "return parameter",
+                );
+                let mut ret_attrs = HashMap::new();
+                ret_attrs.insert("direction".to_string(), serde_json::json!("return"));
+                ret_attrs.insert(
+                    "parameterType".to_string(),
+                    serde_json::json!(&ret.value.type_name),
+                );
+                add_node_and_recurse(
+                    g,
+                    uri,
+                    &ret_qualified,
+                    "return parameter",
+                    ret.value.name.clone(),
+                    span_to_range(&ret.span),
+                    ret_attrs,
+                    Some(calc_id),
+                );
+                add_typing_edge_if_exists(
+                    g,
+                    uri,
+                    &ret_qualified,
+                    &ret.value.type_name,
+                    container_prefix,
+                );
+            }
+            CalcDefBodyElement::Doc(doc) => {
+                super::attach_doc_comment(g, calc_id, &doc.value.text);
+            }
+            CalcDefBodyElement::MetadataAnnotation(meta) => {
+                super::metadata_def::add_metadata_annotation_node(
+                    g,
+                    uri,
+                    container_prefix,
+                    calc_id,
+                    &meta.value,
+                    &meta.span,
+                );
+            }
+            // Directed `in part …` parameter (validation `10b`) -- materialize the same way
+            // every other calc/action/attribute body already does.
+            CalcDefBodyElement::PartUsage(part) => {
+                super::usage_builders::materialize_part_usage(
+                    part,
+                    uri,
+                    container_prefix,
+                    Some(calc_id),
+                    g,
+                );
+            }
+            // Nested `calc` usage inside a calc body (validation `10b` rollups).
+            CalcDefBodyElement::CalcUsage(nested) => {
+                materialize_calc_usage(g, uri, container_prefix, calc_id, nested);
+            }
+            // Nested `calc def` inside a calc body.
+            CalcDefBodyElement::CalcDef(nested) => {
+                build_calc_def(g, uri, container_prefix, Some(calc_id), nested);
+            }
+            CalcDefBodyElement::Expression(_)
+            | CalcDefBodyElement::Other(_)
+            | CalcDefBodyElement::Error(_) => {}
         }
     }
+}
+
+/// Materializes a `calc` usage (named, optionally typed, with its own body) as a child of
+/// `parent_id`: a "calc" node plus recursion into its body via [`build_calc_def_body_elements`].
+/// Shared by every body kind a `calc` usage can nest in directly -- `part_def.rs`'s top-level
+/// `PDBE::CalcUsage`, this module's own nested-`calc`-inside-`calc` rollups (validation `10b`),
+/// and analysis/verification case bodies' `UseCaseDefBodyElement::CalcUsage`.
+pub(super) fn materialize_calc_usage(
+    g: &mut SemanticGraph,
+    uri: &Url,
+    container_prefix: Option<&str>,
+    parent_id: &NodeId,
+    calc_node: &Node<sysml_v2_parser::ast::CalcUsage>,
+) {
+    let name = identification_name(&calc_node.value.identification);
+    let qualified = qualified_name_for_node(g, uri, Some(&parent_id.qualified_name), &name, "calc");
+    let range = span_to_range(&calc_node.span);
+    let mut attrs = HashMap::new();
+    attach_short_name_attribute(&mut attrs, &calc_node.value.identification);
+    attach_membership_visibility(&mut attrs, &calc_node.value.membership);
+    if let Some(ref t) = calc_node.value.type_name {
+        attrs.insert("calcType".to_string(), serde_json::json!(t));
+    }
+    add_node_and_recurse(
+        g,
+        uri,
+        &qualified,
+        "calc",
+        name,
+        range,
+        attrs,
+        Some(parent_id),
+    );
+    if let Some(ref t) = calc_node.value.type_name {
+        add_typing_edge_if_exists(g, uri, &qualified, t, container_prefix);
+    }
+    let calc_id = NodeId::new(uri, &qualified);
+    build_calc_def_body_elements(g, uri, container_prefix, &calc_id, &calc_node.value.body);
 }

--- a/crates/sysml_model/src/semantic/graph_builder/expressions.rs
+++ b/crates/sysml_model/src/semantic/graph_builder/expressions.rs
@@ -493,6 +493,8 @@ pub(super) fn classify_expression(
                 | Expression::Collect { .. }
                 | Expression::Constructor { .. }
                 | Expression::CollectionOp { .. }
+                | Expression::Conditional { .. }
+                | Expression::Extent { .. }
                 | Expression::Null => results.push(ExprClass::Unknown),
             },
             Frame::AfterUnaryOperand => {
@@ -624,6 +626,10 @@ impl ExpressionAlgebra for DebugStringAlgebra {
             }
             Expression::MetadataAccess(_) => format!("{}.metadata", subs[0]),
             Expression::Null => "()".to_string(),
+            Expression::Conditional { .. } => {
+                format!("if {} ? {} else {}", subs[0], subs[1], subs[2])
+            }
+            Expression::Extent { target } => format!("all {target}"),
         }
     }
 }

--- a/crates/sysml_model/src/semantic/graph_builder/interface_def.rs
+++ b/crates/sysml_model/src/semantic/graph_builder/interface_def.rs
@@ -18,7 +18,7 @@ use super::expressions;
 use super::{add_node_and_recurse, qualified_name_for_node};
 use crate::semantic::resolution::resolve_expression_endpoint_qualified;
 
-fn add_end_decl(
+pub(super) fn add_end_decl(
     g: &mut SemanticGraph,
     uri: &Url,
     container_prefix: Option<&str>,
@@ -213,6 +213,11 @@ pub(super) fn build_from_interface_def_body_element(
             Some(parent_id),
             port,
         ),
+        // GH-85 (sysml-v2-parser): bare `flow <a> to <b>;` shorthand connecting two of this
+        // interface's own ends.
+        E::FlowUsage(flow) => {
+            super::flow_usage::materialize_flow_usage(flow, uri, container_prefix, parent_id, g);
+        }
     }
 }
 

--- a/crates/sysml_model/src/semantic/graph_builder/occurrence_body.rs
+++ b/crates/sysml_model/src/semantic/graph_builder/occurrence_body.rs
@@ -167,6 +167,12 @@ pub(super) fn build_from_occurrence_body_element(
         OBE::Error(_) | OBE::Annotation(_) | OBE::Other(_) => {}
         // Not yet modeled in the semantic graph.
         OBE::SuccessionUsage(_) | OBE::Satisfy(_) => {}
+        // `end name : Type;` (or `::>`/nested forms) inside allocation/connection-like
+        // definition bodies (OMG Annex `12b-Allocation-1.sysml`). Same end-declaration shape
+        // `interface_def::add_end_decl` already builds for interface/connection def bodies.
+        OBE::EndDecl(end_node) => {
+            super::interface_def::add_end_decl(g, uri, container_prefix, parent_id, end_node);
+        }
     }
 }
 

--- a/crates/sysml_model/src/semantic/graph_builder/part_def.rs
+++ b/crates/sysml_model/src/semantic/graph_builder/part_def.rs
@@ -1,8 +1,6 @@
 use std::collections::HashMap;
 
-use sysml_v2_parser::ast::{
-    CalcDefBody, CalcDefBodyElement, InterfaceDefBody, PartDefBody, PartDefBodyElement,
-};
+use sysml_v2_parser::ast::{InterfaceDefBody, PartDefBody, PartDefBodyElement};
 use url::Url;
 
 use crate::semantic::ast_util::{
@@ -307,92 +305,13 @@ pub(super) fn build_from_part_def_body_element(
             );
         }
         PDBE::CalcUsage(calc_node) => {
-            let name = identification_name(&calc_node.value.identification);
-            let qualified = qualified_name_for_node(g, uri, container_prefix, &name, "calc");
-            let range = span_to_range(&calc_node.span);
-            let mut attrs = HashMap::new();
-            attach_short_name_attribute(&mut attrs, &calc_node.value.identification);
-            attach_membership_visibility(&mut attrs, &calc_node.value.membership);
-            if let Some(ref t) = calc_node.value.type_name {
-                attrs.insert("calcType".to_string(), serde_json::json!(t));
-            }
-            add_node_and_recurse(
+            super::calc_constraint_def::materialize_calc_usage(
                 g,
                 uri,
-                &qualified,
-                "calc",
-                name,
-                range,
-                attrs,
-                Some(parent_id),
+                container_prefix,
+                parent_id,
+                calc_node,
             );
-            if let Some(ref t) = calc_node.value.type_name {
-                add_typing_edge_if_exists(g, uri, &qualified, t, container_prefix);
-            }
-            if let CalcDefBody::Brace { elements } = &calc_node.value.body {
-                let calc_node_id = NodeId::new(uri, &qualified);
-                for element in elements {
-                    match &element.value {
-                        CalcDefBodyElement::InOutDecl(in_out) => {
-                            super::action::add_in_out_decl(
-                                g,
-                                uri,
-                                container_prefix,
-                                &calc_node_id,
-                                in_out,
-                            );
-                        }
-                        CalcDefBodyElement::ReturnDecl(ret) => {
-                            let ret_qualified = qualified_name_for_node(
-                                g,
-                                uri,
-                                Some(calc_node_id.qualified_name.as_str()),
-                                &ret.value.name,
-                                "return parameter",
-                            );
-                            let mut attrs = HashMap::new();
-                            attrs.insert("direction".to_string(), serde_json::json!("return"));
-                            attrs.insert(
-                                "parameterType".to_string(),
-                                serde_json::json!(&ret.value.type_name),
-                            );
-                            add_node_and_recurse(
-                                g,
-                                uri,
-                                &ret_qualified,
-                                "return parameter",
-                                ret.value.name.clone(),
-                                span_to_range(&ret.span),
-                                attrs,
-                                Some(&calc_node_id),
-                            );
-                            add_typing_edge_if_exists(
-                                g,
-                                uri,
-                                &ret_qualified,
-                                &ret.value.type_name,
-                                container_prefix,
-                            );
-                        }
-                        CalcDefBodyElement::Doc(doc) => {
-                            super::attach_doc_comment(g, &calc_node_id, &doc.value.text);
-                        }
-                        CalcDefBodyElement::MetadataAnnotation(meta) => {
-                            super::metadata_def::add_metadata_annotation_node(
-                                g,
-                                uri,
-                                container_prefix,
-                                &calc_node_id,
-                                &meta.value,
-                                &meta.span,
-                            );
-                        }
-                        CalcDefBodyElement::Expression(_)
-                        | CalcDefBodyElement::Other(_)
-                        | CalcDefBodyElement::Error(_) => {}
-                    }
-                }
-            }
         }
         // A `case`/`case def` nested inside a `part def { ... }` body was previously dropped
         // entirely -- no dispatch arm existed here, unlike the sibling `PDBE::CalcUsage` arm

--- a/crates/sysml_model/src/semantic/graph_builder/requirement_body.rs
+++ b/crates/sysml_model/src/semantic/graph_builder/requirement_body.rs
@@ -130,6 +130,10 @@ fn require_constraint_display_lines(body: &RequireConstraintBody) -> Vec<String>
                     }
                     ConstraintDefBodyElement::Error(_) | ConstraintDefBodyElement::Other(_) => {}
                     ConstraintDefBodyElement::MetadataAnnotation(_) => {}
+                    // Not surfaced in this flat display-line summary (mirrors the `Other`/`Error`
+                    // arms above -- nested content isn't rendered here today).
+                    ConstraintDefBodyElement::Constraint(_)
+                    | ConstraintDefBodyElement::AttributeUsage(_) => {}
                 }
             }
             if lines.is_empty() {
@@ -183,6 +187,10 @@ fn require_constraint_structured(
                 metadata_names.push(meta.value.name.clone());
             }
             ConstraintDefBodyElement::Error(_) | ConstraintDefBodyElement::Other(_) => {}
+            // Not surfaced in this flat structured summary (mirrors the `Other`/`Error` arms
+            // above -- nested content isn't rendered here today).
+            ConstraintDefBodyElement::Constraint(_)
+            | ConstraintDefBodyElement::AttributeUsage(_) => {}
         }
     }
     let expression = compact_whitespace(&expression_fragments.join(" "));
@@ -799,6 +807,34 @@ pub(super) fn walk_requirement_def_body(
             RequirementDefBodyElement::Annotation(_)
             | RequirementDefBodyElement::Error(_)
             | RequirementDefBodyElement::Other(_) => {}
+            // `subject;` shorthand (concern/viewpoint bodies, validation `11a`): the parser's
+            // own `SubjectRef` is a zero-field marker -- it doesn't declare a new subject, it
+            // just acknowledges inheriting the enclosing one, which
+            // `inherit_requirement_subjects` already wires separately. Nothing to build here.
+            RequirementDefBodyElement::SubjectRef(_) => {}
+            // `variant name;` inside a `variation requirement` body (validation `7b`) -- same
+            // materializer `part_def.rs`/`part_usage.rs` already use for `variant` members.
+            RequirementDefBodyElement::VariantUsage(variant) => {
+                super::usage_builders::materialize_variant_usage(
+                    variant,
+                    uri,
+                    type_resolution_prefix,
+                    parent_id,
+                    g,
+                );
+            }
+            // Bare `constraint` member nested in a requirement def body (distinct from
+            // `RequireConstraint`'s `assume`/`require`-prefixed forms) -- same
+            // `build_constraint_usage` package-level constraint usages already use.
+            RequirementDefBodyElement::Constraint(constraint) => {
+                super::calc_constraint_def::build_constraint_usage(
+                    g,
+                    uri,
+                    type_resolution_prefix,
+                    Some(parent_id),
+                    constraint,
+                );
+            }
         }
     }
 }

--- a/crates/sysml_model/src/semantic/graph_builder/state.rs
+++ b/crates/sysml_model/src/semantic/graph_builder/state.rs
@@ -519,6 +519,9 @@ pub(super) fn build_from_state_body(
             SDBE::Doc(doc) => {
                 super::attach_doc_comment(g, parent_id, &doc.value.text);
             }
+            SDBE::InOutDecl(in_out) => {
+                super::action::add_in_out_decl(g, uri, container_prefix, parent_id, in_out);
+            }
             SDBE::Error(_) | SDBE::Annotation(_) | SDBE::Other(_) => {}
         }
     }

--- a/crates/sysml_model/src/semantic/graph_builder/use_case.rs
+++ b/crates/sysml_model/src/semantic/graph_builder/use_case.rs
@@ -480,6 +480,77 @@ pub(super) fn wire_extended_case_body_element(
             }
             false
         }
+        // Nested `action` usage in analysis/verification case bodies (validation `09`).
+        UCBE::ActionUsage(au) => {
+            super::action::materialize_top_level_action_usage(
+                g,
+                uri,
+                container_prefix,
+                Some(parent_id),
+                au.as_ref(),
+            );
+            true
+        }
+        // Nested `analysis` usage in analysis case bodies (validation `10a`).
+        UCBE::AnalysisCaseUsage(n) => {
+            super::package_body::materialize_analysis_case_usage(
+                g,
+                uri,
+                container_prefix,
+                Some(parent_id),
+                n,
+            );
+            true
+        }
+        // Nested `calc` usage in analysis case bodies (validation `10b`).
+        UCBE::CalcUsage(n) => {
+            super::calc_constraint_def::materialize_calc_usage(
+                g,
+                uri,
+                container_prefix,
+                parent_id,
+                n,
+            );
+            true
+        }
+        // `attribute` usage / directed `in attribute …` (validation `10c`/`10d`).
+        UCBE::AttributeUsage(n) => {
+            super::usage_builders::materialize_attribute_usage(
+                n,
+                uri,
+                container_prefix,
+                parent_id,
+                g,
+            );
+            true
+        }
+        // Directed `in requirement …` parameter (validation `10c`).
+        UCBE::RequirementUsage(n) => {
+            super::usage_builders::materialize_requirement_usage(
+                n,
+                uri,
+                container_prefix,
+                Some(parent_id),
+                g,
+            );
+            true
+        }
+        // Directed `in part …` / nested part usage in analysis bodies.
+        UCBE::PartUsage(n) => {
+            super::usage_builders::materialize_part_usage(
+                n,
+                uri,
+                container_prefix,
+                Some(parent_id),
+                g,
+            );
+            true
+        }
+        // Bare result expression in analysis case bodies (validation `10a`: `vehicle.mass`) --
+        // analysis-specific semantics (feeds `analysis_result_qualified`/
+        // `inherited_case_result_qualified`), left to each caller's own body walker rather than
+        // handled generically here.
+        UCBE::Expression(_) => false,
         _ => false,
     }
 }

--- a/crates/sysml_model/src/semantic/graph_builder/verification.rs
+++ b/crates/sysml_model/src/semantic/graph_builder/verification.rs
@@ -361,7 +361,19 @@ pub(super) fn build_from_verification_body(
             | UseCaseDefBodyElement::FirstSuccession(_)
             | UseCaseDefBodyElement::ThenUseCaseUsage(_)
             | UseCaseDefBodyElement::RefRedefinition(_)
-            | UseCaseDefBodyElement::SubjectRef(_) => {}
+            | UseCaseDefBodyElement::SubjectRef(_)
+            // Nested action/analysis/calc/attribute/requirement/part usages: already fully
+            // materialized by `wire_extended_case_body_element` above (which returns `true` and
+            // `continue`s before this match runs) -- these arms are unreachable, kept only for
+            // exhaustiveness.
+            | UseCaseDefBodyElement::ActionUsage(_)
+            | UseCaseDefBodyElement::AnalysisCaseUsage(_)
+            | UseCaseDefBodyElement::CalcUsage(_)
+            | UseCaseDefBodyElement::AttributeUsage(_)
+            | UseCaseDefBodyElement::RequirementUsage(_)
+            | UseCaseDefBodyElement::PartUsage(_)
+            // Bare result expression -- not modeled in verification-case bodies.
+            | UseCaseDefBodyElement::Expression(_) => {}
             UseCaseDefBodyElement::Doc(doc) => {
                 super::attach_doc_comment(g, parent_id, &doc.value.text);
             }

--- a/crates/sysml_tokens/src/ast_ranges.rs
+++ b/crates/sysml_tokens/src/ast_ranges.rs
@@ -648,6 +648,29 @@ fn collect_semantic_ranges_attribute_body(
             AttributeBodyElement::Doc(_)
             | AttributeBodyElement::Error(_)
             | AttributeBodyElement::Other(_) => {}
+            // `ref`/`ref part` members (validation `15_11`/`15_19`/`17a`/`17b`) -- same
+            // collector every other body kind's `RefDecl` arm already uses.
+            AttributeBodyElement::RefDecl(ref_decl) => {
+                collect_semantic_ranges_ref_decl(ref_decl, out);
+            }
+            // Nested `part` usage inside an item/attribute body (validation `3e`/`14c`) -- same
+            // shape `OBE::PartUsage` above already highlights.
+            AttributeBodyElement::PartUsage(part_usage) => {
+                if let Some(ref span) = part_usage.value.name_span {
+                    out.push((span_to_source_range(span), TYPE_PROPERTY));
+                }
+                if let Some(ref span) = part_usage.value.type_ref_span {
+                    out.push((span_to_source_range(span), TYPE_TYPE));
+                }
+                if let PartUsageBody::Brace { elements } = &part_usage.value.body {
+                    for child in elements {
+                        collect_semantic_ranges_part_usage_body_element(ctx, child, out);
+                    }
+                }
+            }
+            // No dedicated highlighting yet (mirrors every other body kind's `AssertConstraint`
+            // arm in this file).
+            AttributeBodyElement::AssertConstraint(_) => {}
         }
     }
 }
@@ -763,6 +786,7 @@ fn collect_semantic_ranges_state_def_body_element(
                 }
             }
         }
+        SDBE::InOutDecl(in_out) => out.push((span_to_source_range(&in_out.span), TYPE_PROPERTY)),
         SDBE::Entry(_)
         | SDBE::Do(_)
         | SDBE::Exit(_)
@@ -817,6 +841,16 @@ fn collect_semantic_ranges_occurrence_body_element(
             collect_semantic_ranges_definition_body(ctx, &flow.value.body, out);
         }
         OBE::StateUsage(state_usage) => collect_semantic_ranges_state_usage(ctx, state_usage, out),
+        // `end name : Type;` (or nested forms) inside allocation/connection-like definition
+        // bodies -- same highlighting `CDBE::EndDecl`/`IDBE::EndDecl` already use.
+        OBE::EndDecl(end_decl) => {
+            if let Some(ref span) = end_decl.name_span {
+                out.push((span_to_source_range(span), TYPE_PROPERTY));
+            }
+            if let Some(ref span) = end_decl.type_ref_span {
+                out.push((span_to_source_range(span), TYPE_TYPE));
+            }
+        }
         OBE::Doc(_)
         | OBE::Error(_)
         | OBE::Annotation(_)
@@ -1321,6 +1355,20 @@ fn collect_semantic_ranges_requirement_def_body_element(
         }
         RDBE::Doc(_) | RDBE::Error(_) | RDBE::Other(_) | RDBE::Annotation(_) => {}
         RDBE::MetadataAnnotation(meta) => collect_semantic_ranges_metadata_annotation(meta, out),
+        // `subject;` shorthand (concern/viewpoint bodies, validation `11a`) -- mirrors
+        // `RDBE::SubjectDecl`'s simple whole-span highlight (no separate name to point at).
+        RDBE::SubjectRef(subject_ref) => {
+            out.push((span_to_source_range(&subject_ref.span), TYPE_PROPERTY));
+        }
+        // `variant name;` inside a `variation requirement` body (validation `7b`) -- same
+        // whole-span highlight `PDBE::VariantUsage` already uses.
+        RDBE::VariantUsage(variant) => {
+            out.push((span_to_source_range(&variant.span), TYPE_PROPERTY));
+        }
+        // Bare `constraint` member nested in a requirement def body.
+        RDBE::Constraint(constraint) => {
+            out.push((span_to_source_range(&constraint.span), TYPE_PROPERTY));
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Bumps `sysml-v2-parser` 0.53.0 → 0.54.0 (`PARSE_AST_VERSION` 70 → 71). Pulls in [sysml-v2-parser#70](https://github.com/elan8/sysml-v2-parser/issues/70) (`parse()`/`parse_for_editor()` equivalence), the [#78](https://github.com/elan8/sysml-v2-parser/issues/78) follow-up (full-library strict-diagnostics gaps), and [#85](https://github.com/elan8/sysml-v2-parser/issues/85) (connector-end/interface/flow shorthand gaps).
- spec42's pin was last synced *before* the whole #78 AST-eq gap-closure work landed upstream, so this bump surfaced 19 non-exhaustive-match compile errors plus 2 real breaking-type changes across `sysml_model` and `sysml_tokens` — a bigger catch-up than just my own upstream #85 changes.
- Every new AST variant got real graph-builder/semantic-token handling (not stub catch-alls): mirrored the closest existing sibling variant's materialization, reused shared helpers where one already existed (`materialize_part_usage`, `materialize_attribute_usage`, `materialize_requirement_usage`, `materialize_top_level_action_usage`, `materialize_analysis_case_usage`, `collect_semantic_ranges_ref_decl`), and factored two new shared functions where duplication would otherwise have tripled (`calc_constraint_def::{build_calc_def_body_elements,materialize_calc_usage}`, now shared by `part_def.rs`'s top-level `calc` usage arm, nested calc-in-calc rollups, and analysis/verification case bodies' nested `calc` usages).
- Fixed two independent real breaking changes: `RefBody::Brace`'s elements are now `RefBodyElement`-wrapped (`action.rs`'s `add_ref_decl` now filters to the `Action(..)` variant before recursing), and `CaseReturnDecl.value_expression` was renamed/retyped to `value: Option<Node<FeatureValue>>` (`analysis_case.rs` now unwraps `.value.expression`).
- A couple of genuinely new constructs (a bare analysis-case result expression, `AssertConstraint` in newly-reachable body contexts) are left as documented no-ops rather than guessed at, matching this codebase's existing "not yet modeled" precedent for the same constructs elsewhere.

Partial step on #18, not a 1.0 pin confirmation — the OMG-library-baseline validation and roadmap-documentation acceptance criteria are still open.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo doc --no-deps --workspace`
- [x] `cargo test --workspace` (130 suites, 0 failures)
- [x] `cargo audit` (no new advisories — pre-existing `bincode` unmaintained warning only)
- [x] `node scripts/sync-workspace-version.mjs --check`, `sync-standard-library-config.mjs --check`, `sync-kpar-libraries-config.mjs --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)