### PR TITLE
chore: release v0.50.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.50.0] - 2026-08-07
+
 - **Bumped `sysml-v2-parser` 0.53.0 → 0.54.0** ([#18](https://github.com/elan8/spec42/issues/18)) —
   pulls in #70 (`parse()`/`parse_for_editor()` equivalence), the #78 follow-up (full-library
   strict-diagnostics gaps: `in`/`ref`/`calc` redefinition forms, nested `calc def`, `abstract

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,7 +361,7 @@ dependencies = [
 
 [[package]]
 name = "diagram"
-version = "0.49.0"
+version = "0.50.0"
 dependencies = [
  "serde",
 ]
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "kpar"
-version = "0.49.0"
+version = "0.50.0"
 dependencies = [
  "chrono",
  "clap",
@@ -852,7 +852,7 @@ dependencies = [
 
 [[package]]
 name = "language_service"
-version = "0.49.0"
+version = "0.50.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "lsp_server"
-version = "0.49.0"
+version = "0.50.0"
 dependencies = [
  "clap",
  "glob",
@@ -1359,7 +1359,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.49.0"
+version = "0.50.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1518,7 +1518,7 @@ dependencies = [
 
 [[package]]
 name = "sysml_diagnostics"
-version = "0.49.0"
+version = "0.50.0"
 dependencies = [
  "serde_json",
  "sysml-v2-parser",
@@ -1528,7 +1528,7 @@ dependencies = [
 
 [[package]]
 name = "sysml_model"
-version = "0.49.0"
+version = "0.50.0"
 dependencies = [
  "ignore",
  "petgraph",
@@ -1545,7 +1545,7 @@ dependencies = [
 
 [[package]]
 name = "sysml_tokens"
-version = "0.49.0"
+version = "0.50.0"
 dependencies = [
  "serde",
  "sysml-v2-parser",
@@ -2135,7 +2135,7 @@ dependencies = [
 
 [[package]]
 name = "workspace"
-version = "0.49.0"
+version = "0.50.0"
 dependencies = [
  "bincode",
  "directories",
@@ -2161,7 +2161,7 @@ dependencies = [
 
 [[package]]
 name = "workspace_session"
-version = "0.49.0"
+version = "0.50.0"
 dependencies = [
  "thiserror 2.0.19",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.49.0"
+version = "0.50.0"
 edition = "2021"
 authors = ["Elan8"]
 license = "MIT"

--- a/vscode/package-lock.json
+++ b/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "spec42",
-  "version": "0.49.0",
+  "version": "0.50.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "spec42",
-      "version": "0.49.0",
+      "version": "0.50.0",
       "license": "MIT",
       "dependencies": {
         "d3": "^7.9.0",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -4,7 +4,7 @@
   "publisher": "Elan8",
   "icon": "logo/logo.png",
   "description": "Open, local-first SysML v2 and KerML tooling: live editing, model exploration, diagrams, and the same analysis engine for CI and assistants.",
-  "version": "0.49.0",
+  "version": "0.50.0",
   "license": "MIT",
   "keywords": [
     "sysml",

--- a/zed/Cargo.lock
+++ b/zed/Cargo.lock
@@ -496,7 +496,7 @@ dependencies = [
 
 [[package]]
 name = "spec42-zed"
-version = "0.49.0"
+version = "0.50.0"
 dependencies = [
  "zed_extension_api",
 ]

--- a/zed/Cargo.toml
+++ b/zed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spec42-zed"
-version = "0.49.0"
+version = "0.50.0"
 edition = "2021"
 description = "Zed extension for SysML v2 language support via the spec42 LSP"
 license = "MIT"

--- a/zed/extension.toml
+++ b/zed/extension.toml
@@ -1,7 +1,7 @@
 id = "sysml-v2"
 name = "SysML v2"
 description = "SysML v2 language support for Zed via the Spec42 language server."
-version = "0.49.0"
+version = "0.50.0"
 schema_version = 1
 authors = ["Elan8"]
 repository = "https://github.com/elan8/spec42"


### PR DESCRIPTION
## Summary
- Bump workspace version 0.49.0 → 0.50.0 across Cargo.toml, VS Code extension, and Zed extension manifests (via `sync-workspace-version.mjs`)
- Finalize CHANGELOG.md: move `[Unreleased]` content under a new `[0.50.0] - 2026-08-07` heading, including the `sysml-v2-parser` 0.53.0 → 0.54.0 update (#18)

## Test plan
- [x] `cargo fmt --check`
- [x] `node scripts/sync-workspace-version.mjs --check`
- [x] `node scripts/sync-standard-library-config.mjs --check`
- [x] `node scripts/sync-kpar-libraries-config.mjs --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace`
- [x] `cargo test --workspace` (130/130 passing)
- [x] `cargo audit` (clean aside from the pre-existing allowed bincode warning, tracked in #57)

🤖 Generated with [Claude Code](https://claude.com/claude-code)