### PR TITLE
fix: key IBD root_views/root_candidates by qualified name

### DIFF
--- a/crates/lsp_server/tests/integration/model.rs
+++ b/crates/lsp_server/tests/integration/model.rs
@@ -1778,8 +1778,8 @@ fn lsp_sysml_model_ibd_surveillance_drone_is_complete_enough_for_interconnection
     let default_root = ibd["defaultRoot"].as_str().expect("default root");
 
     assert_eq!(
-        default_root, "droneInstance",
-        "expected instance root to be selected by default"
+        default_root, "SurveillanceDrone.droneInstance",
+        "expected instance root to be selected by default, keyed by qualified name"
     );
     assert!(
         connectors.len() >= 14,

--- a/crates/sysml_model/src/semantic/ibd/extract_impl.rs
+++ b/crates/sysml_model/src/semantic/ibd/extract_impl.rs
@@ -528,7 +528,7 @@ pub fn build_ibd_for_uri(graph: &SemanticGraph, uri: &Url) -> IbdDataDto {
 
     let root_candidates: Vec<String> = roots_with_metrics
         .iter()
-        .map(|(p, _, _, _)| p.name.clone())
+        .map(|(p, _, _, _)| p.qualified_name.clone())
         .collect();
     let default_root = root_candidates.first().cloned();
     let mut root_views: std::collections::BTreeMap<String, IbdRootViewDto> =
@@ -579,7 +579,7 @@ pub fn build_ibd_for_uri(graph: &SemanticGraph, uri: &Url) -> IbdDataDto {
             .cloned()
             .collect();
         root_views.insert(
-            p.name.clone(),
+            p.qualified_name.clone(),
             IbdRootViewDto {
                 parts: focused_parts,
                 ports: focused_ports,

--- a/crates/sysml_model/src/semantic/ibd/extract_impl/tests.rs
+++ b/crates/sysml_model/src/semantic/ibd/extract_impl/tests.rs
@@ -291,7 +291,9 @@ fn build_ibd_mirrors_definition_connections_onto_cross_file_instance() {
 
     let root_view = merged
         .root_views
-        .get("webshopSystem")
+        .iter()
+        .find(|(key, _)| key.ends_with("webshopSystem"))
+        .map(|(_, view)| view)
         .expect("webshopSystem root view");
     assert!(
         root_view.connectors.iter().any(|connector| {
@@ -576,7 +578,9 @@ fn build_ibd_expands_library_typed_part_usage() {
         .expect("semantic graph should build");
     let ibd = build_ibd_for_uri(&graph, &uri);
     assert!(
-        ibd.root_candidates.iter().any(|root| root == "robot"),
+        ibd.root_candidates
+            .iter()
+            .any(|root| root.ends_with("robot")),
         "expected robot as IBD root, got {:?}",
         ibd.root_candidates
     );
@@ -648,9 +652,10 @@ fn build_ibd_surveillance_drone_instance_has_nested_parts_and_connectors() {
     let uri = Url::parse("memory://workspace/surveillance_drone_full.sysml").expect("uri");
     let ibd = build_ibd_for_uri(&graph, &uri);
 
-    assert_eq!(
-        ibd.default_root.as_deref(),
-        Some("droneInstance"),
+    assert!(
+        ibd.default_root
+            .as_deref()
+            .is_some_and(|root| root.ends_with("droneInstance")),
         "expected drone instance as default root, got {:?}",
         ibd.default_root
     );
@@ -826,7 +831,9 @@ fn build_ibd_resolves_connectors_with_bare_own_port_endpoint_and_no_phantom_pack
 
     let view = ibd
         .root_views
-        .get("driveModule")
+        .iter()
+        .find(|(key, _)| key.ends_with("driveModule"))
+        .map(|(_, view)| view)
         .expect("expected a driveModule root view");
 
     assert_eq!(

--- a/crates/sysml_model/src/semantic/ibd/merge.rs
+++ b/crates/sysml_model/src/semantic/ibd/merge.rs
@@ -215,7 +215,7 @@ fn merge_ibd_payloads_inner(ibds: Vec<IbdDataDto>, enrich_connectors: bool) -> I
             let is_instance = view
                 .parts
                 .iter()
-                .find(|part| part.name == **name)
+                .find(|part| part.qualified_name == **name)
                 .map(|part| is_part_instance_kind(&part.element_type))
                 .unwrap_or(false);
             let instance_bonus = if is_instance { 1usize } else { 0usize };
@@ -377,6 +377,89 @@ mod tests {
             connector_keys,
             vec![(port_c_out.port_id.as_str(), port_a_in.port_id.as_str())],
             "connectors must be sorted by (source_id, target_id, rel_type)"
+        );
+    }
+
+    /// #27 regression: `root_views` is keyed by each root's `qualified_name`, not its bare local
+    /// name. Two roots in different packages sharing the same local name ("System") must stay
+    /// distinct entries after merge instead of additively combining into one.
+    #[test]
+    fn merge_keeps_root_views_distinct_for_same_local_name_in_different_packages() {
+        let pkg1_system = part("Pkg1::System");
+        let pkg1_child = part("Pkg1::System::partA");
+        let pkg2_system = part("Pkg2::System");
+        let pkg2_child = part("Pkg2::System::partB");
+
+        let root_view = |root: &IbdPartDto, child: &IbdPartDto| IbdRootViewDto {
+            parts: vec![root.clone(), child.clone()],
+            ports: Vec::new(),
+            connectors: Vec::new(),
+            container_groups: Vec::new(),
+            package_container_groups: Vec::new(),
+        };
+
+        let ibd_pkg1 = IbdDataDto {
+            parts: vec![pkg1_system.clone(), pkg1_child.clone()],
+            ports: Vec::new(),
+            connectors: Vec::new(),
+            container_groups: Vec::new(),
+            package_container_groups: Vec::new(),
+            root_candidates: vec![pkg1_system.qualified_name.clone()],
+            default_root: Some(pkg1_system.qualified_name.clone()),
+            root_views: [(
+                pkg1_system.qualified_name.clone(),
+                root_view(&pkg1_system, &pkg1_child),
+            )]
+            .into_iter()
+            .collect(),
+            def_instance_mappings: Vec::new(),
+        };
+        let ibd_pkg2 = IbdDataDto {
+            parts: vec![pkg2_system.clone(), pkg2_child.clone()],
+            ports: Vec::new(),
+            connectors: Vec::new(),
+            container_groups: Vec::new(),
+            package_container_groups: Vec::new(),
+            root_candidates: vec![pkg2_system.qualified_name.clone()],
+            default_root: Some(pkg2_system.qualified_name.clone()),
+            root_views: [(
+                pkg2_system.qualified_name.clone(),
+                root_view(&pkg2_system, &pkg2_child),
+            )]
+            .into_iter()
+            .collect(),
+            def_instance_mappings: Vec::new(),
+        };
+
+        let merged = merge_ibd_payloads_for_workspace_finalize(vec![ibd_pkg1, ibd_pkg2]);
+
+        assert_eq!(
+            merged.root_views.len(),
+            2,
+            "expected two distinct root views, got {:?}",
+            merged.root_views.keys().collect::<Vec<_>>()
+        );
+
+        let pkg1_view = merged
+            .root_views
+            .get(&pkg1_system.qualified_name)
+            .expect("Pkg1.System root view");
+        let pkg1_ids: HashSet<&str> = pkg1_view.parts.iter().map(|p| p.id.as_str()).collect();
+        assert_eq!(
+            pkg1_ids,
+            HashSet::from(["Pkg1::System", "Pkg1::System::partA"]),
+            "Pkg1.System root view must not pick up Pkg2's child part"
+        );
+
+        let pkg2_view = merged
+            .root_views
+            .get(&pkg2_system.qualified_name)
+            .expect("Pkg2.System root view");
+        let pkg2_ids: HashSet<&str> = pkg2_view.parts.iter().map(|p| p.id.as_str()).collect();
+        assert_eq!(
+            pkg2_ids,
+            HashSet::from(["Pkg2::System", "Pkg2::System::partB"]),
+            "Pkg2.System root view must not pick up Pkg1's child part"
         );
     }
 }


### PR DESCRIPTION
## Summary
- `root_views` (and `root_candidates`/`default_root`) were keyed by each root's bare local `name`, so two distinct roots sharing a local name in different packages (e.g. two `System` parts) would additively merge into a single root view during workspace merge — a latent footgun, safe today only because other callers re-resolve by qualified id
- Key by `qualified_name` instead in `extract_impl.rs`, which is unique per root; fixed the one consumer (`merge.rs`'s `default_root` scoring) that assumed the key was a bare name
- Verified via `git grep` that every other consumer (`ibd_scope.rs`, `connectors.rs`, `projection.rs`) treats the key opaquely, and that no VS Code frontend code displays `rootCandidates`/`defaultRoot`/`rootViews` keys as user-facing labels — so this is a pure correctness fix with no UI impact

## Test plan
- [x] New regression test `merge_keeps_root_views_distinct_for_same_local_name_in_different_packages` — confirmed it fails against the old bare-name keying before verifying it passes with the fix
- [x] Updated 5 existing tests that hardcoded bare-name key expectations, including a real end-to-end LSP integration test asserting the `defaultRoot` field the extension receives
- [x] `cargo test --workspace` (all green)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace`

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)