### PR TITLE
fix: emit view_expose_empty_result when filters wipe resolved exposes

### DIFF
--- a/crates/sysml_diagnostics/src/checks/view_metadata_conformance.rs
+++ b/crates/sysml_diagnostics/src/checks/view_metadata_conformance.rs
@@ -15,7 +15,9 @@ use sysml_model::semantic::relationships::{
 };
 use sysml_model::semantic::standard_views::is_non_standard_explicit_view_type;
 use sysml_model::semantic::text_span::TextRange;
-use sysml_model::SemanticGraph;
+use sysml_model::{
+    element_type_matches_all_filters, parse_filter_text, FilterExpr, SemanticGraph,
+};
 
 const BUILTIN_MODELED_DECL_KEYWORDS: &[&str] = &[
     "feature",
@@ -179,6 +181,74 @@ pub(crate) fn collect_view_metadata_conformance_diagnostics(
                 ExposeTargetResolution::Resolved(_) => {}
             }
         }
+    }
+
+    for node in graph.nodes_for_uri(uri) {
+        if node.element_kind != ElementKind::View || is_synthetic(node) {
+            continue;
+        }
+        let Some(targets) = node
+            .attributes
+            .get("exposeTargets")
+            .and_then(|value| value.as_array())
+        else {
+            continue;
+        };
+        let filters = collect_view_body_filters(graph, node);
+        if filters.is_empty() {
+            continue;
+        }
+        let container_prefix = node
+            .id
+            .qualified_name
+            .rsplit_once("::")
+            .map(|(prefix, _)| prefix);
+        let mut resolved_any = false;
+        let mut surviving = false;
+        for target in targets {
+            let Some(target_text) = target.get("target").and_then(|value| value.as_str()) else {
+                continue;
+            };
+            let ExposeTargetResolution::Resolved(names) =
+                resolve_expose_target(graph, Some(uri), container_prefix, target_text)
+            else {
+                continue;
+            };
+            if names.is_empty() {
+                continue;
+            }
+            resolved_any = true;
+            for name in names {
+                let Some(element_type) = element_type_for_qualified_name(graph, &name) else {
+                    continue;
+                };
+                if element_type_matches_all_filters(element_type, &filters) {
+                    surviving = true;
+                    break;
+                }
+            }
+            if surviving {
+                break;
+            }
+        }
+        if !resolved_any || surviving {
+            continue;
+        }
+        let key = format!("expose_empty_result|{}", node.id.qualified_name);
+        if !seen.insert(key) {
+            continue;
+        }
+        diagnostics.push(diag(
+            uri,
+            diagnostic_range(graph, node, None),
+            DiagnosticSeverity::Information,
+            "semantic",
+            "view_expose_empty_result",
+            format!(
+                "View '{}' expose targets resolve, but view filters remove all exposed elements.",
+                node.name
+            ),
+        ));
     }
 
     for node in graph.nodes_for_uri(uri) {
@@ -696,6 +766,33 @@ fn expose_target_entry_range(
         }
     }
     node.range
+}
+
+fn collect_view_body_filters(
+    graph: &SemanticGraph,
+    view: &sysml_model::semantic::model::SemanticNode,
+) -> Vec<FilterExpr> {
+    graph
+        .children_of(view)
+        .into_iter()
+        .filter(|child| child.element_kind == ElementKind::Filter)
+        .filter_map(|child| {
+            child
+                .attributes
+                .get("condition")
+                .and_then(|value| value.as_str())
+                .map(|text| parse_filter_text(text.trim()))
+        })
+        .collect()
+}
+
+fn element_type_for_qualified_name<'a>(
+    graph: &'a SemanticGraph,
+    qualified_name: &str,
+) -> Option<&'a str> {
+    let ids = graph.node_ids_for_qualified_name(qualified_name)?;
+    let id = ids.first()?;
+    Some(graph.get_node(id)?.element_kind.as_str())
 }
 
 fn annotated_element_matches_restriction(

--- a/crates/sysml_diagnostics/src/checks/view_metadata_conformance.rs
+++ b/crates/sysml_diagnostics/src/checks/view_metadata_conformance.rs
@@ -15,9 +15,7 @@ use sysml_model::semantic::relationships::{
 };
 use sysml_model::semantic::standard_views::is_non_standard_explicit_view_type;
 use sysml_model::semantic::text_span::TextRange;
-use sysml_model::{
-    element_type_matches_all_filters, parse_filter_text, FilterExpr, SemanticGraph,
-};
+use sysml_model::{element_type_matches_all_filters, parse_filter_text, FilterExpr, SemanticGraph};
 
 const BUILTIN_MODELED_DECL_KEYWORDS: &[&str] = &[
     "feature",

--- a/crates/sysml_model/src/lib.rs
+++ b/crates/sysml_model/src/lib.rs
@@ -18,9 +18,9 @@ pub use semantic::evaluation::{
     evaluate_expressions, evaluate_expressions_with_unit_catalogs, UnitRegistry,
 };
 pub use semantic::explicit_views::{
-    build_view_candidates, build_view_catalog, evaluate_views, project_ids_for_renderer,
-    renderer_view_for_view_type, EvaluatedView, ExposeSpec, FilterExpr, ViewCatalog,
-    ViewDefinitionSpec, ViewUsageSpec,
+    build_view_candidates, build_view_catalog, element_type_matches_all_filters, evaluate_views,
+    parse_filter_text, project_ids_for_renderer, renderer_view_for_view_type, EvaluatedView,
+    ExposeSpec, FilterExpr, ViewCatalog, ViewDefinitionSpec, ViewUsageSpec,
 };
 pub use semantic::extracted_model::extract_activity_diagrams;
 pub use semantic::graph::{PendingExpressionRelationship, PendingRelationship, SemanticGraph};

--- a/crates/sysml_model/src/semantic/explicit_views.rs
+++ b/crates/sysml_model/src/semantic/explicit_views.rs
@@ -114,6 +114,7 @@ mod filter_match;
 mod filter_parser;
 pub(crate) use catalog_build::*;
 pub use evaluate::*;
+pub use filter_match::element_type_matches_all_filters;
 pub(crate) use filter_match::*;
 pub(crate) use filter_parser::*;
 
@@ -152,7 +153,13 @@ fn span_to_range_dto(span: &Span) -> RangeDto {
     }
 }
 
-pub(crate) fn parse_filter_text(text: &str) -> FilterExpr {
+/// Parse a view/expose filter expression text into a [`FilterExpr`] tree.
+///
+/// Accepts the same textual subset used by SysML view `filter` members (for example
+/// `@SysML::PartUsage or @SysML::PartDefinition`). Also accepts the debug-serialized
+/// `condition` attribute stored on graph `filter` nodes, which uses the same `@Kind`
+/// form for classification expressions.
+pub fn parse_filter_text(text: &str) -> FilterExpr {
     let tokens = tokenize_filter(text);
     let mut parser = FilterParser { tokens, index: 0 };
     parser.parse_expr()

--- a/crates/sysml_model/src/semantic/explicit_views/filter_match.rs
+++ b/crates/sysml_model/src/semantic/explicit_views/filter_match.rs
@@ -5,9 +5,9 @@ pub(crate) fn node_matches_all_filters(
     node_by_id: &HashMap<&str, &crate::semantic::dto::GraphNodeDto>,
     filters: &[FilterExpr],
 ) -> bool {
-    filters
-        .iter()
-        .all(|filter| match_filter_expr(filter, node_id, node_by_id))
+    node_by_id
+        .get(node_id)
+        .is_some_and(|node| element_type_matches_all_filters(&node.element_type, filters))
 }
 
 pub(crate) fn node_matches_expose_filter(
@@ -15,42 +15,43 @@ pub(crate) fn node_matches_expose_filter(
     node_by_id: &HashMap<&str, &crate::semantic::dto::GraphNodeDto>,
     filter: Option<&FilterExpr>,
 ) -> bool {
-    filter.is_none_or(|expr| match_filter_expr(expr, node_id, node_by_id))
+    filter.is_none_or(|expr| {
+        node_by_id
+            .get(node_id)
+            .is_some_and(|node| element_type_matches_filter(&node.element_type, expr))
+    })
 }
 
-pub(crate) fn match_filter_expr(
-    filter: &FilterExpr,
-    node_id: &str,
-    node_by_id: &HashMap<&str, &crate::semantic::dto::GraphNodeDto>,
-) -> bool {
+/// Whether `element_type` (a semantic `element_kind` string) survives every filter.
+pub fn element_type_matches_all_filters(element_type: &str, filters: &[FilterExpr]) -> bool {
+    filters
+        .iter()
+        .all(|filter| element_type_matches_filter(element_type, filter))
+}
+
+pub(crate) fn element_type_matches_filter(element_type: &str, filter: &FilterExpr) -> bool {
     match filter {
-        FilterExpr::Matches(qualified) => node_matches_kind(node_id, qualified, node_by_id),
-        FilterExpr::Not(inner) => !match_filter_expr(inner, node_id, node_by_id),
+        FilterExpr::Matches(qualified) => element_type_matches_kind(element_type, qualified),
+        FilterExpr::Not(inner) => !element_type_matches_filter(element_type, inner),
         FilterExpr::And(left, right) => {
-            match_filter_expr(left, node_id, node_by_id)
-                && match_filter_expr(right, node_id, node_by_id)
+            element_type_matches_filter(element_type, left)
+                && element_type_matches_filter(element_type, right)
         }
         FilterExpr::Or(left, right) => {
-            match_filter_expr(left, node_id, node_by_id)
-                || match_filter_expr(right, node_id, node_by_id)
+            element_type_matches_filter(element_type, left)
+                || element_type_matches_filter(element_type, right)
         }
         FilterExpr::Unsupported(_) => false,
     }
 }
 
-pub(crate) fn node_matches_kind(
-    node_id: &str,
-    qualified: &str,
-    node_by_id: &HashMap<&str, &crate::semantic::dto::GraphNodeDto>,
-) -> bool {
+pub(crate) fn element_type_matches_kind(element_type: &str, qualified: &str) -> bool {
     let wanted = normalize_kind_name(qualified);
-    node_by_id.get(node_id).is_some_and(|node| {
-        let actual = node.element_type.to_lowercase();
-        actual == wanted
-            || actual.contains(&wanted)
-            || wanted.contains(actual.as_str())
-            || actual == map_sysml_kind_alias(&wanted)
-    })
+    let actual = element_type.to_lowercase();
+    actual == wanted
+        || actual.contains(&wanted)
+        || wanted.contains(actual.as_str())
+        || actual == map_sysml_kind_alias(&wanted)
 }
 
 pub(crate) fn map_sysml_kind_alias(wanted: &str) -> String {

--- a/crates/sysml_model/tests/p2_diagnostics_semantics.rs
+++ b/crates/sysml_model/tests/p2_diagnostics_semantics.rs
@@ -146,6 +146,66 @@ fn view_without_expose_emits_empty_expose_diagnostic() {
 }
 
 #[test]
+fn view_filters_removing_all_resolved_exposes_emit_empty_result() {
+    let doc = workspace_doc(
+        "view_empty_result.sysml",
+        r#"package Demo {
+  part def Engine;
+  part engine : Engine;
+  view structure : GeneralView {
+    expose Demo::engine;
+    filter @SysML::RequirementUsage;
+  }
+}"#,
+    );
+    let uri = doc.uri.clone();
+    let (graph, _parsed) = build_semantic_graph_from_documents(&[doc]).expect("graph");
+    let diagnostics = collect_diagnostics_from_graph(&graph, &uri, DiagnosticsOptions::default());
+    assert!(
+        has_code(&diagnostics, "view_expose_empty_result"),
+        "expected view_expose_empty_result, got: {:?}",
+        diagnostics
+            .iter()
+            .map(|d| (&d.code, &d.message))
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        !has_code(&diagnostics, "view_expose_unresolved"),
+        "expose should resolve; empty result is a filter outcome, got: {:?}",
+        diagnostics
+            .iter()
+            .map(|d| (&d.code, &d.message))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn view_filters_that_keep_resolved_exposes_do_not_emit_empty_result() {
+    let doc = workspace_doc(
+        "view_kept_result.sysml",
+        r#"package Demo {
+  part def Engine;
+  part engine : Engine;
+  view structure : GeneralView {
+    expose Demo::engine;
+    filter @SysML::PartUsage;
+  }
+}"#,
+    );
+    let uri = doc.uri.clone();
+    let (graph, _parsed) = build_semantic_graph_from_documents(&[doc]).expect("graph");
+    let diagnostics = collect_diagnostics_from_graph(&graph, &uri, DiagnosticsOptions::default());
+    assert!(
+        !has_code(&diagnostics, "view_expose_empty_result"),
+        "PartUsage filter should keep the exposed part, got: {:?}",
+        diagnostics
+            .iter()
+            .map(|d| (&d.code, &d.message))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn untyped_metadata_annotation_emits_unresolved_diagnostic() {
     let doc = workspace_doc(
         "metadata_unresolved.sysml",

--- a/docs/engineering/DIAGNOSTIC-CATALOG.md
+++ b/docs/engineering/DIAGNOSTIC-CATALOG.md
@@ -198,7 +198,7 @@ Spec areas: 7.26-7.27, 8.3.26, 8.4.22-8.4.23.
 - Done: `view_rendering_invalid_target` — view rendering membership target kind validation.
 - Done: `view_expose_empty` — view body without expose members.
 - Done: `view_expose_unresolved` — expose target/feature chain does not resolve.
-- Done: `view_expose_empty_result` — catalog entry reserved for filters removing all exposed elements; emission tracked in [#31](https://github.com/elan8/spec42/issues/31).
+- Done: `view_expose_empty_result` — filters remove all elements from an otherwise resolved expose ([#31](https://github.com/elan8/spec42/issues/31)).
 - Done: `view_filter_non_boolean` — view body filter expression Boolean validation.
 - Done: `viewpoint_reference_unresolved` / `viewpoint_rep_language_unresolved` — viewpoint frame/import/stakeholder/purpose targets and missing rep language.
 - Done: `metadata_annotation_unresolved` — metadata annotation target resolution when untyped.


### PR DESCRIPTION
## Summary
- Emit `view_expose_empty_result` when a view expose resolves but view-body filters remove every exposed element
- Reuse filter matching via a shared `element_type_matches_all_filters` helper (same kind rules as view evaluation)
- Cover empty vs kept cases in `p2_diagnostics_semantics`; mark catalog entry as emitted

## Test plan
- [x] `cargo test -p sysml_model --test p2_diagnostics_semantics`
- [x] `cargo clippy -p sysml_model -p sysml_diagnostics --all-targets -- -D warnings`

Closes #31