### PR TITLE
fix: highlight Satisfy, Dependency, and KerML package members

### DIFF
--- a/crates/sysml_tokens/src/ast_ranges.rs
+++ b/crates/sysml_tokens/src/ast_ranges.rs
@@ -14,10 +14,11 @@ use sysml_v2_parser::ast::{
 use sysml_v2_parser::RootNamespace;
 
 use crate::ast_util::{
-    identification_name, push_ident_definition_spans, push_usage_name_type_spans,
-    span_to_source_range, SourceRange,
+    identification_name, modeled_decl_name, push_ident_definition_spans,
+    push_usage_name_type_spans, push_word_token, span_to_source_range, SourceRange,
 };
 use crate::types::*;
+use sysml_v2_parser::ast::{Dependency, Satisfy};
 
 struct RangeCtx<'a> {
     source: &'a str,
@@ -583,8 +584,112 @@ fn collect_semantic_ranges_package_body_element(
                 push_ident_definition_spans(&actor_node.span, None, TYPE_PROPERTY, out);
             }
         }
+        PBE::Satisfy(satisfy_node) => collect_semantic_ranges_satisfy(ctx, satisfy_node, out),
+        PBE::Dependency(dep_node) => collect_semantic_ranges_dependency(ctx, dep_node, out),
+        PBE::FeatureDecl(feature_node) => {
+            collect_semantic_ranges_modeled_decl(
+                ctx,
+                &feature_node.span,
+                &feature_node.value.keyword,
+                &feature_node.value.text,
+                TYPE_PROPERTY,
+                out,
+            );
+        }
+        PBE::ClassifierDecl(classifier_node) => {
+            collect_semantic_ranges_modeled_decl(
+                ctx,
+                &classifier_node.span,
+                &classifier_node.value.keyword,
+                &classifier_node.value.text,
+                TYPE_CLASS,
+                out,
+            );
+        }
+        PBE::KermlFeatureDecl(decl) => {
+            collect_semantic_ranges_modeled_decl(
+                ctx,
+                &decl.span,
+                &decl.value.bnf_production,
+                &decl.value.text,
+                TYPE_PROPERTY,
+                out,
+            );
+        }
+        PBE::KermlSemanticDecl(decl) => {
+            collect_semantic_ranges_modeled_decl(
+                ctx,
+                &decl.span,
+                &decl.value.bnf_production,
+                &decl.value.text,
+                TYPE_CLASS,
+                out,
+            );
+        }
+        PBE::ExtendedLibraryDecl(decl) => {
+            collect_semantic_ranges_modeled_decl(
+                ctx,
+                &decl.span,
+                &decl.value.bnf_production,
+                &decl.value.text,
+                TYPE_CLASS,
+                out,
+            );
+        }
         _ => {}
     }
+}
+
+fn collect_semantic_ranges_satisfy(
+    ctx: &RangeCtx<'_>,
+    satisfy: &sysml_v2_parser::Node<Satisfy>,
+    out: &mut Vec<(SourceRange, u32)>,
+) {
+    out.push((
+        span_to_source_range(&satisfy.value.source.span),
+        TYPE_PROPERTY,
+    ));
+    out.push((
+        span_to_source_range(&satisfy.value.target.span),
+        TYPE_PROPERTY,
+    ));
+    if let Some(inline) = &satisfy.value.inline_requirement {
+        push_word_token(ctx.source, &satisfy.span, &inline.name, TYPE_PROPERTY, out);
+        if let Some(type_name) = inline.type_name.as_deref() {
+            push_word_token(ctx.source, &satisfy.span, type_name, TYPE_TYPE, out);
+        }
+    }
+}
+
+fn collect_semantic_ranges_dependency(
+    ctx: &RangeCtx<'_>,
+    dependency: &sysml_v2_parser::Node<Dependency>,
+    out: &mut Vec<(SourceRange, u32)>,
+) {
+    if let Some(ident) = &dependency.value.identification {
+        let name = identification_name(ident);
+        push_word_token(ctx.source, &dependency.span, &name, TYPE_PROPERTY, out);
+    }
+    for client in &dependency.value.clients {
+        push_word_token(ctx.source, &dependency.span, client, TYPE_PROPERTY, out);
+    }
+    for supplier in &dependency.value.suppliers {
+        push_word_token(ctx.source, &dependency.span, supplier, TYPE_PROPERTY, out);
+    }
+}
+
+fn collect_semantic_ranges_modeled_decl(
+    ctx: &RangeCtx<'_>,
+    span: &sysml_v2_parser::Span,
+    keyword: &str,
+    text: &str,
+    token_type: u32,
+    out: &mut Vec<(SourceRange, u32)>,
+) {
+    let Some(name) = modeled_decl_name(keyword, text) else {
+        return;
+    };
+    push_word_token(ctx.source, span, &name, token_type, out);
 }
 
 fn collect_semantic_ranges_definition_body(
@@ -851,14 +956,14 @@ fn collect_semantic_ranges_occurrence_body_element(
                 out.push((span_to_source_range(span), TYPE_TYPE));
             }
         }
+        OBE::Satisfy(satisfy) => collect_semantic_ranges_satisfy(ctx, satisfy, out),
         OBE::Doc(_)
         | OBE::Error(_)
         | OBE::Annotation(_)
         | OBE::AssertConstraint(_)
         | OBE::Allocate(_)
         | OBE::Other(_)
-        | OBE::SuccessionUsage(_)
-        | OBE::Satisfy(_) => {}
+        | OBE::SuccessionUsage(_) => {}
     }
 }
 
@@ -1046,6 +1151,8 @@ fn collect_semantic_ranges_part_def_body_element(
         }
         PDBE::ActionUsage(usage) => collect_semantic_ranges_action_usage(ctx, usage.as_ref(), out),
         PDBE::StateUsage(state_usage) => collect_semantic_ranges_state_usage(ctx, state_usage, out),
+        PDBE::Satisfy(satisfy) => collect_semantic_ranges_satisfy(ctx, satisfy, out),
+        PDBE::Dependency(dep) => collect_semantic_ranges_dependency(ctx, dep, out),
         PDBE::Connect(_)
         | PDBE::InterfaceUsage(_)
         | PDBE::Allocate(_)
@@ -1056,7 +1163,6 @@ fn collect_semantic_ranges_part_def_body_element(
         | PDBE::Doc(_)
         | PDBE::Comment(_)
         | PDBE::AssertConstraint(_)
-        | PDBE::Satisfy(_)
         | PDBE::Other(_) => {}
         PDBE::VariantUsage(n) => {
             out.push((span_to_source_range(&n.span), TYPE_PROPERTY));
@@ -1109,6 +1215,7 @@ fn collect_semantic_ranges_part_usage_body_element(
         }
         PUBE::ActionUsage(usage) => collect_semantic_ranges_action_usage(ctx, usage.as_ref(), out),
         PUBE::StateUsage(state_usage) => collect_semantic_ranges_state_usage(ctx, state_usage, out),
+        PUBE::Satisfy(satisfy) => collect_semantic_ranges_satisfy(ctx, satisfy, out),
         _ => {}
     }
 }

--- a/crates/sysml_tokens/src/ast_util.rs
+++ b/crates/sysml_tokens/src/ast_util.rs
@@ -269,3 +269,54 @@ pub fn push_usage_name_type_spans<T: TypeNameRef + ?Sized>(
         }
     }
 }
+
+/// Best-effort declared name from a KerML modeled declaration (`FeatureDecl` /
+/// `ClassifierDecl` / similar), mirroring graph-builder name extraction.
+pub fn modeled_decl_name(keyword: &str, text: &str) -> Option<String> {
+    let t = text.trim().trim_end_matches(';').trim();
+    let tokens: Vec<&str> = t.split_whitespace().collect();
+    let kw = keyword.trim();
+    if let Some(pos) = tokens.iter().position(|tok| tok.eq_ignore_ascii_case(kw)) {
+        let mut i = pos + 1;
+        while i < tokens.len() {
+            let tok = tokens[i].trim_end_matches([';', ',', ')', '{']);
+            if tok.eq_ignore_ascii_case("def")
+                || tok.eq_ignore_ascii_case("id")
+                || tok.eq_ignore_ascii_case("case")
+                || tok.starts_with('\'')
+            {
+                i += 1;
+                continue;
+            }
+            if tok.eq_ignore_ascii_case("specializes") {
+                break;
+            }
+            let name: String = tok
+                .chars()
+                .filter(|c| c.is_alphanumeric() || *c == '_')
+                .collect();
+            if !name.is_empty() {
+                return Some(name);
+            }
+            break;
+        }
+    }
+    None
+}
+
+/// Push a whole-word occurrence of `name` inside `span` when present in `source`.
+pub fn push_word_token(
+    source: &str,
+    span: &Span,
+    name: &str,
+    token_type: u32,
+    out: &mut Vec<(SourceRange, u32)>,
+) {
+    if name.is_empty() {
+        return;
+    }
+    let local = name.rsplit("::").next().unwrap_or(name);
+    if let Some(r) = word_range_within_span(source, &span_to_source_range(span), local) {
+        out.push((r, token_type));
+    }
+}

--- a/crates/sysml_tokens/tests/satisfy_dependency_tokens.rs
+++ b/crates/sysml_tokens/tests/satisfy_dependency_tokens.rs
@@ -1,0 +1,201 @@
+//! Golden-style checks for Satisfy / Dependency / KerML package-member semantic tokens.
+
+use sysml_tokens::{
+    ast_semantic_ranges, semantic_tokens_full, TYPE_CLASS, TYPE_INTERFACE, TYPE_KEYWORD,
+    TYPE_PROPERTY, TYPE_TYPE,
+};
+use sysml_v2_parser::parse_for_editor;
+
+fn decode_semantic_tokens(data: &[u32]) -> Vec<(u32, u32, u32, u32)> {
+    let mut line: u32 = 0;
+    let mut start_char: u32 = 0;
+    let mut tokens = Vec::new();
+    let mut i = 0;
+    while i + 5 <= data.len() {
+        line += data[i];
+        start_char = if data[i] == 0 {
+            start_char + data[i + 1]
+        } else {
+            data[i + 1]
+        };
+        let length = data[i + 2];
+        let token_type = data[i + 3];
+        tokens.push((line, start_char, length, token_type));
+        i += 5;
+    }
+    tokens
+}
+
+fn token_type_on_line(
+    content: &str,
+    tokens: &[(u32, u32, u32, u32)],
+    line: u32,
+    ident: &str,
+) -> Option<u32> {
+    let lines: Vec<&str> = content.lines().collect();
+    tokens.iter().find_map(|(ln, start, len, ty)| {
+        if *ln != line {
+            return None;
+        }
+        let line_str = lines.get(*ln as usize)?;
+        let text: String = line_str
+            .chars()
+            .skip(*start as usize)
+            .take(*len as usize)
+            .collect();
+        if text == ident {
+            Some(*ty)
+        } else {
+            None
+        }
+    })
+}
+
+#[test]
+fn satisfy_member_tokenizes_source_and_target() {
+    let content = r#"package Demo {
+  requirement def EnduranceReq;
+  part def Drone;
+  requirement endurance : EnduranceReq;
+  part droneInstance : Drone;
+  satisfy endurance by droneInstance;
+}"#;
+    let parsed = parse_for_editor(content);
+    let ranges = ast_semantic_ranges(&parsed.root, content);
+    let (tokens, _) = semantic_tokens_full(content, Some(&ranges));
+    let decoded = decode_semantic_tokens(&tokens.data);
+
+    assert_eq!(
+        token_type_on_line(content, &decoded, 5, "satisfy"),
+        Some(TYPE_KEYWORD)
+    );
+    assert_eq!(
+        token_type_on_line(content, &decoded, 5, "endurance"),
+        Some(TYPE_PROPERTY),
+        "satisfy source should be a property"
+    );
+    assert_eq!(
+        token_type_on_line(content, &decoded, 5, "droneInstance"),
+        Some(TYPE_PROPERTY),
+        "satisfy target should be a property"
+    );
+}
+
+#[test]
+fn dependency_member_tokenizes_clients_and_suppliers() {
+    let content = r#"package Demo {
+  part def Client;
+  part def Supplier;
+  part client : Client;
+  part supplier : Supplier;
+  dependency from client to supplier;
+}"#;
+    let parsed = parse_for_editor(content);
+    let ranges = ast_semantic_ranges(&parsed.root, content);
+    let (tokens, _) = semantic_tokens_full(content, Some(&ranges));
+    let decoded = decode_semantic_tokens(&tokens.data);
+
+    assert_eq!(
+        token_type_on_line(content, &decoded, 5, "dependency"),
+        Some(TYPE_KEYWORD)
+    );
+    assert_eq!(
+        token_type_on_line(content, &decoded, 5, "client"),
+        Some(TYPE_PROPERTY),
+        "dependency client should be a property"
+    );
+    assert_eq!(
+        token_type_on_line(content, &decoded, 5, "supplier"),
+        Some(TYPE_PROPERTY),
+        "dependency supplier should be a property"
+    );
+}
+
+#[test]
+fn kerml_classifier_and_feature_decls_tokenized() {
+    let content = r#"package KerMLDecls {
+  datatype Magnitude;
+  feature baseType;
+}"#;
+    let parsed = parse_for_editor(content);
+    let ranges = ast_semantic_ranges(&parsed.root, content);
+    let (tokens, _) = semantic_tokens_full(content, Some(&ranges));
+    let decoded = decode_semantic_tokens(&tokens.data);
+
+    assert_eq!(
+        token_type_on_line(content, &decoded, 1, "Magnitude"),
+        Some(TYPE_CLASS),
+        "KerML classifier decl name should be class, got {:?}",
+        token_type_on_line(content, &decoded, 1, "Magnitude")
+    );
+    assert_eq!(
+        token_type_on_line(content, &decoded, 2, "baseType"),
+        Some(TYPE_PROPERTY),
+        "KerML feature decl name should be property, got {:?}",
+        token_type_on_line(content, &decoded, 2, "baseType")
+    );
+}
+
+#[test]
+fn vehicle_definitions_fixture_tokenizes_part_port_and_interface_names() {
+    // Self-contained excerpt patterned on the OMG Vehicle Example's VehicleDefinitions.sysml
+    // (no library imports required for these declaration headers).
+    let content = r#"package VehicleDefinitions {
+  part def Vehicle {
+    attribute mass : Real;
+  }
+  part def Transmission;
+  part def AxleAssembly;
+  part def Axle {
+    port leftMountingPoint : AxleMountIF;
+    port rightMountingPoint : AxleMountIF;
+  }
+  part def Wheel {
+    port hub : WheelHubIF;
+  }
+  port def AxleMountIF;
+  port def WheelHubIF;
+  interface def Mounting {
+    end axleMount : AxleMountIF;
+    end hub : WheelHubIF;
+  }
+}"#;
+    let parsed = parse_for_editor(content);
+    let ranges = ast_semantic_ranges(&parsed.root, content);
+    let (tokens, _) = semantic_tokens_full(content, Some(&ranges));
+    let decoded = decode_semantic_tokens(&tokens.data);
+
+    for (line, name, expected) in [
+        (1, "Vehicle", TYPE_CLASS),
+        (4, "Transmission", TYPE_CLASS),
+        (5, "AxleAssembly", TYPE_CLASS),
+        (6, "Axle", TYPE_CLASS),
+        (10, "Wheel", TYPE_CLASS),
+        (13, "AxleMountIF", TYPE_TYPE),
+        (14, "WheelHubIF", TYPE_TYPE),
+        (15, "Mounting", TYPE_INTERFACE),
+    ] {
+        assert_eq!(
+            token_type_on_line(content, &decoded, line, name),
+            Some(expected),
+            "{name} on line {line}"
+        );
+    }
+
+    assert_eq!(
+        token_type_on_line(content, &decoded, 2, "mass"),
+        Some(TYPE_PROPERTY)
+    );
+    assert_eq!(
+        token_type_on_line(content, &decoded, 7, "leftMountingPoint"),
+        Some(TYPE_PROPERTY)
+    );
+    assert_eq!(
+        token_type_on_line(content, &decoded, 7, "AxleMountIF"),
+        Some(TYPE_TYPE)
+    );
+    assert_eq!(
+        token_type_on_line(content, &decoded, 16, "axleMount"),
+        Some(TYPE_PROPERTY)
+    );
+}


### PR DESCRIPTION
## Summary
- Color `satisfy` source/target (and inline requirement name/type) plus `dependency` clients/suppliers via AST semantic ranges
- Highlight KerML package members (`FeatureDecl`, `ClassifierDecl`, and related modeled decls)
- Add golden tests covering satisfy/dependency/KerML decls and a self-contained VehicleDefinitions-style fixture

## Test plan
- [x] `cargo test -p sysml_tokens`
- [x] `cargo clippy -p sysml_tokens --all-targets -- -D warnings`

Closes #34