### PR TITLE
fix: materialize anonymous definitions (#32)

### DIFF
--- a/crates/sysml_model/src/semantic/graph_builder/calc_constraint_def.rs
+++ b/crates/sysml_model/src/semantic/graph_builder/calc_constraint_def.rs
@@ -12,7 +12,7 @@ use url::Url;
 
 use super::{
     add_node_and_recurse, insert_def_specialization_attr, qualified_name_for_node,
-    wire_def_specialization_edge,
+    resolve_addressable_name, wire_def_specialization_edge,
 };
 use crate::semantic::ast_util::{
     attach_membership_visibility, attach_short_name_attribute, identification_name, span_to_range,
@@ -162,13 +162,14 @@ pub(super) fn build_constraint_def(
     parent_id: Option<&NodeId>,
     c_node: &Node<ConstraintDef>,
 ) {
-    let name = identification_name(&c_node.value.identification);
-    if name.is_empty() {
-        return;
-    }
+    let mut attrs = HashMap::new();
+    let name = resolve_addressable_name(
+        &identification_name(&c_node.value.identification),
+        "constraint def",
+        &mut attrs,
+    );
     let qualified = qualified_name_for_node(g, uri, container_prefix, &name, "constraint def");
     let (params, expression) = extract_constraint_metadata(uri, &c_node.value.body);
-    let mut attrs = HashMap::new();
     attrs.insert(
         "analysisKind".to_string(),
         serde_json::json!("constraint_def"),
@@ -222,13 +223,10 @@ pub(super) fn build_constraint_usage(
     parent_id: Option<&NodeId>,
     c_node: &Node<ConstraintUsage>,
 ) {
-    let name = c_node.value.name.clone();
-    if name.is_empty() {
-        return;
-    }
+    let mut attrs = HashMap::new();
+    let name = resolve_addressable_name(&c_node.value.name, "constraint", &mut attrs);
     let qualified = qualified_name_for_node(g, uri, container_prefix, &name, "constraint");
     let (params, expression) = extract_constraint_metadata(uri, &c_node.value.body);
-    let mut attrs = HashMap::new();
     attach_membership_visibility(&mut attrs, &c_node.value.membership);
     attrs.insert(
         "analysisKind".to_string(),
@@ -274,13 +272,14 @@ pub(super) fn build_calc_def(
     parent_id: Option<&NodeId>,
     c_node: &Node<CalcDef>,
 ) {
-    let name = identification_name(&c_node.value.identification);
-    if name.is_empty() {
-        return;
-    }
+    let mut attrs = HashMap::new();
+    let name = resolve_addressable_name(
+        &identification_name(&c_node.value.identification),
+        "calc def",
+        &mut attrs,
+    );
     let qualified = qualified_name_for_node(g, uri, container_prefix, &name, "calc def");
     let (params, return_decl, expression) = extract_calc_metadata(uri, &c_node.value.body);
-    let mut attrs = HashMap::new();
     attrs.insert("analysisKind".to_string(), serde_json::json!("calc_def"));
     let params_json = serde_json::Value::Array(params.clone());
     attrs.insert("analysisParams".to_string(), params_json.clone());

--- a/crates/sysml_model/src/semantic/graph_builder/mod.rs
+++ b/crates/sysml_model/src/semantic/graph_builder/mod.rs
@@ -142,6 +142,45 @@ pub(super) fn effective_usage_name<'a>(
     }
 }
 
+/// Kind-tagged synthetic base name for anonymous elements (`"item def"` → `"_itemDef"`).
+///
+/// Used with [`qualified_name_for_node`], which appends `#kind` / `#kindN` on sibling collisions.
+pub(super) fn anonymous_element_base_name(kind: &str) -> String {
+    let mut camel = String::from("_");
+    for (i, part) in kind.split_whitespace().enumerate() {
+        if i == 0 {
+            camel.push_str(part);
+            continue;
+        }
+        let mut chars = part.chars();
+        if let Some(first) = chars.next() {
+            camel.extend(first.to_uppercase());
+            camel.push_str(chars.as_str());
+        }
+    }
+    if camel == "_" {
+        "_element".to_string()
+    } else {
+        camel
+    }
+}
+
+/// Prefer a declared identification name; when empty, return a kind-tagged synthetic name and
+/// mark `attrs["isAnonymous"] = true` so anonymous-but-legal defs/usages stay addressable
+/// ([#32](https://github.com/elan8/spec42/issues/32)).
+pub(super) fn resolve_addressable_name(
+    declared: &str,
+    kind: &str,
+    attrs: &mut HashMap<String, serde_json::Value>,
+) -> String {
+    let declared = declared.trim();
+    if !declared.is_empty() {
+        return declared.to_string();
+    }
+    attrs.insert("isAnonymous".to_string(), serde_json::json!(true));
+    anonymous_element_base_name(kind)
+}
+
 /// Returns a qualified name that is unique among siblings. When a node with the same
 /// base qualified name already exists (e.g. package and part def with same name), appends
 /// #kind to disambiguate.
@@ -387,5 +426,39 @@ mod short_name_tests {
              removed, got {:#?}",
             graph.node_ids_by_qualified_name.get("Demo::CB")
         );
+    }
+}
+
+#[cfg(test)]
+mod anonymous_name_tests {
+    use super::{anonymous_element_base_name, resolve_addressable_name};
+    use std::collections::HashMap;
+
+    #[test]
+    fn kind_tagged_base_names() {
+        assert_eq!(anonymous_element_base_name("item def"), "_itemDef");
+        assert_eq!(
+            anonymous_element_base_name("constraint def"),
+            "_constraintDef"
+        );
+        assert_eq!(anonymous_element_base_name("calc def"), "_calcDef");
+        assert_eq!(anonymous_element_base_name("constraint"), "_constraint");
+        assert_eq!(anonymous_element_base_name(""), "_element");
+    }
+
+    #[test]
+    fn resolve_marks_anonymous_and_preserves_declared() {
+        let mut attrs = HashMap::new();
+        assert_eq!(
+            resolve_addressable_name("Widget", "item def", &mut attrs),
+            "Widget"
+        );
+        assert!(attrs.is_empty());
+
+        assert_eq!(
+            resolve_addressable_name("", "item def", &mut attrs),
+            "_itemDef"
+        );
+        assert_eq!(attrs.get("isAnonymous"), Some(&serde_json::json!(true)));
     }
 }

--- a/crates/sysml_model/src/semantic/graph_builder/package_body/materialize.rs
+++ b/crates/sysml_model/src/semantic/graph_builder/package_body/materialize.rs
@@ -10,10 +10,14 @@ pub(super) fn materialize_part_def(
     parent_id: Option<&NodeId>,
     pd_node: &Node<PartDef>,
 ) {
-    let name = identification_name(&pd_node.identification);
+    let mut attrs = HashMap::new();
+    let name = resolve_addressable_name(
+        &identification_name(&pd_node.identification),
+        "part def",
+        &mut attrs,
+    );
     let qualified = qualified_name_for_node(g, uri, container_prefix, &name, "part def");
     let range = span_to_range(&pd_node.span);
-    let mut attrs = HashMap::new();
     attach_short_name_attribute(&mut attrs, &pd_node.identification);
     attach_membership_visibility(&mut attrs, &pd_node.membership);
     if let Some(ref p) = pd_node.definition_prefix {
@@ -139,10 +143,14 @@ pub(crate) fn materialize_port_def(
     parent_id: Option<&NodeId>,
     pd_node: &Node<PortDef>,
 ) {
-    let name = identification_name(&pd_node.identification);
+    let mut attrs = HashMap::new();
+    let name = resolve_addressable_name(
+        &identification_name(&pd_node.identification),
+        "port def",
+        &mut attrs,
+    );
     let qualified = qualified_name_for_node(g, uri, container_prefix, &name, "port def");
     let range = span_to_range(&pd_node.span);
-    let mut attrs = HashMap::new();
     attach_short_name_attribute(&mut attrs, &pd_node.identification);
     attach_membership_visibility(&mut attrs, &pd_node.membership);
     insert_def_specialization_attr(&mut attrs, pd_node.specializes.as_deref());
@@ -339,10 +347,14 @@ pub(super) fn materialize_requirement_def(
     parent_id: Option<&NodeId>,
     rd_node: &Node<RequirementDef>,
 ) {
-    let name = identification_name(&rd_node.identification);
+    let mut attrs = HashMap::new();
+    let name = resolve_addressable_name(
+        &identification_name(&rd_node.identification),
+        "requirement def",
+        &mut attrs,
+    );
     let qualified = qualified_name_for_node(g, uri, container_prefix, &name, "requirement def");
     let range = span_to_range(&rd_node.span);
-    let mut attrs = HashMap::new();
     attach_short_name_attribute(&mut attrs, &rd_node.identification);
     attach_membership_visibility(&mut attrs, &rd_node.membership);
     insert_def_specialization_attr(&mut attrs, rd_node.specializes.as_deref());
@@ -588,12 +600,13 @@ pub(crate) fn materialize_item_def(
     parent_id: Option<&NodeId>,
     item_node: &Node<ItemDef>,
 ) {
-    let name = identification_name(&item_node.identification);
-    if name.is_empty() {
-        return;
-    }
-    let qualified = qualified_name_for_node(g, uri, container_prefix, &name, "item def");
     let mut attrs = HashMap::new();
+    let name = resolve_addressable_name(
+        &identification_name(&item_node.identification),
+        "item def",
+        &mut attrs,
+    );
+    let qualified = qualified_name_for_node(g, uri, container_prefix, &name, "item def");
     attach_short_name_attribute(&mut attrs, &item_node.identification);
     attach_membership_visibility(&mut attrs, &item_node.membership);
     insert_def_specialization_attr(&mut attrs, item_node.specializes.as_deref());
@@ -625,12 +638,13 @@ pub(super) fn materialize_individual_def(
     parent_id: Option<&NodeId>,
     ind_node: &Node<IndividualDef>,
 ) {
-    let name = identification_name(&ind_node.identification);
-    if name.is_empty() {
-        return;
-    }
-    let qualified = qualified_name_for_node(g, uri, container_prefix, &name, "individual def");
     let mut attrs = HashMap::new();
+    let name = resolve_addressable_name(
+        &identification_name(&ind_node.identification),
+        "individual def",
+        &mut attrs,
+    );
+    let qualified = qualified_name_for_node(g, uri, container_prefix, &name, "individual def");
     attach_short_name_attribute(&mut attrs, &ind_node.identification);
     attach_membership_visibility(&mut attrs, &ind_node.membership);
     insert_def_specialization_attr(&mut attrs, ind_node.specializes.as_deref());
@@ -662,12 +676,13 @@ pub(super) fn materialize_metadata_def(
     parent_id: Option<&NodeId>,
     md_node: &Node<MetadataDef>,
 ) {
-    let name = identification_name(&md_node.identification);
-    if name.is_empty() {
-        return;
-    }
-    let qualified = qualified_name_for_node(g, uri, container_prefix, &name, "metadata def");
     let mut attrs = HashMap::new();
+    let name = resolve_addressable_name(
+        &identification_name(&md_node.identification),
+        "metadata def",
+        &mut attrs,
+    );
+    let qualified = qualified_name_for_node(g, uri, container_prefix, &name, "metadata def");
     attach_short_name_attribute(&mut attrs, &md_node.identification);
     attach_membership_visibility(&mut attrs, &md_node.membership);
     insert_def_specialization_attr(&mut attrs, md_node.specializes.as_deref());
@@ -705,12 +720,13 @@ pub(super) fn materialize_enum_def(
     parent_id: Option<&NodeId>,
     enum_node: &Node<EnumDef>,
 ) {
-    let name = identification_name(&enum_node.identification);
-    if name.is_empty() {
-        return;
-    }
-    let qualified = qualified_name_for_node(g, uri, container_prefix, &name, "enum def");
     let mut attrs = HashMap::new();
+    let name = resolve_addressable_name(
+        &identification_name(&enum_node.identification),
+        "enum def",
+        &mut attrs,
+    );
+    let qualified = qualified_name_for_node(g, uri, container_prefix, &name, "enum def");
     attach_short_name_attribute(&mut attrs, &enum_node.identification);
     attach_membership_visibility(&mut attrs, &enum_node.membership);
     insert_def_specialization_attr(&mut attrs, enum_node.specializes.as_deref());
@@ -747,10 +763,8 @@ fn materialize_enumerated_values(
 ) {
     let parent_id = NodeId::new(uri, enum_def_qualified);
     for value_node in values {
-        let name = value_node.value.name.clone();
-        if name.is_empty() {
-            continue;
-        }
+        let mut attrs = HashMap::new();
+        let name = resolve_addressable_name(&value_node.value.name, "enumerated value", &mut attrs);
         let qualified =
             qualified_name_for_node(g, uri, Some(enum_def_qualified), &name, "enumerated value");
         add_node_and_recurse(
@@ -760,7 +774,7 @@ fn materialize_enumerated_values(
             "enumerated value",
             name,
             span_to_range(&value_node.span),
-            HashMap::new(),
+            attrs,
             Some(&parent_id),
         );
     }
@@ -808,12 +822,13 @@ pub(super) fn materialize_occurrence_def(
     parent_id: Option<&NodeId>,
     occ_node: &Node<OccurrenceDef>,
 ) {
-    let name = identification_name(&occ_node.identification);
-    if name.is_empty() {
-        return;
-    }
-    let qualified = qualified_name_for_node(g, uri, container_prefix, &name, "occurrence def");
     let mut attrs = HashMap::new();
+    let name = resolve_addressable_name(
+        &identification_name(&occ_node.identification),
+        "occurrence def",
+        &mut attrs,
+    );
+    let qualified = qualified_name_for_node(g, uri, container_prefix, &name, "occurrence def");
     attach_short_name_attribute(&mut attrs, &occ_node.identification);
     attach_membership_visibility(&mut attrs, &occ_node.membership);
     insert_def_specialization_attr(&mut attrs, occ_node.specializes.as_deref());
@@ -859,18 +874,15 @@ pub(super) fn materialize_connection_def(
     parent_id: Option<&NodeId>,
     conn_node: &Node<ConnectionDef>,
 ) {
-    let name = identification_name(&conn_node.identification);
     let annotation = conn_node.annotation.as_deref();
-    let base_name = if name.is_empty() {
-        if annotation == Some("derivation") {
-            "_derivationConnection"
-        } else {
-            "_connectionDef"
-        }
-    } else {
-        name.as_str()
-    };
     let mut attrs = HashMap::new();
+    let declared = identification_name(&conn_node.identification);
+    let base_name = if declared.is_empty() && annotation == Some("derivation") {
+        attrs.insert("isAnonymous".to_string(), serde_json::json!(true));
+        "_derivationConnection".to_string()
+    } else {
+        resolve_addressable_name(&declared, "connection def", &mut attrs)
+    };
     attach_short_name_attribute(&mut attrs, &conn_node.identification);
     attach_membership_visibility(&mut attrs, &conn_node.membership);
     if let Some(annotation) = annotation {
@@ -880,7 +892,7 @@ pub(super) fn materialize_connection_def(
         );
     }
     insert_def_specialization_attr(&mut attrs, conn_node.specializes.as_deref());
-    let qualified = qualified_name_for_node(g, uri, container_prefix, base_name, "connection def");
+    let qualified = qualified_name_for_node(g, uri, container_prefix, &base_name, "connection def");
     add_node_and_recurse(
         g,
         uri,
@@ -890,7 +902,7 @@ pub(super) fn materialize_connection_def(
         } else {
             "connection def"
         },
-        base_name.to_string(),
+        base_name,
         span_to_range(&conn_node.span),
         attrs,
         parent_id,
@@ -918,12 +930,13 @@ pub(super) fn materialize_flow_def(
     parent_id: Option<&NodeId>,
     flow_node: &Node<sysml_v2_parser::ast::FlowDef>,
 ) {
-    let name = identification_name(&flow_node.identification);
-    if name.is_empty() {
-        return;
-    }
-    let qualified = qualified_name_for_node(g, uri, container_prefix, &name, "flow def");
     let mut attrs = HashMap::new();
+    let name = resolve_addressable_name(
+        &identification_name(&flow_node.identification),
+        "flow def",
+        &mut attrs,
+    );
+    let qualified = qualified_name_for_node(g, uri, container_prefix, &name, "flow def");
     attach_short_name_attribute(&mut attrs, &flow_node.identification);
     attach_membership_visibility(&mut attrs, &flow_node.membership);
     insert_def_specialization_attr(&mut attrs, flow_node.specializes.as_deref());
@@ -961,12 +974,13 @@ pub(super) fn materialize_allocation_def(
     parent_id: Option<&NodeId>,
     alloc_node: &Node<AllocationDef>,
 ) {
-    let name = identification_name(&alloc_node.identification);
-    if name.is_empty() {
-        return;
-    }
-    let qualified = qualified_name_for_node(g, uri, container_prefix, &name, "allocation def");
     let mut attrs = HashMap::new();
+    let name = resolve_addressable_name(
+        &identification_name(&alloc_node.identification),
+        "allocation def",
+        &mut attrs,
+    );
+    let qualified = qualified_name_for_node(g, uri, container_prefix, &name, "allocation def");
     attach_short_name_attribute(&mut attrs, &alloc_node.identification);
     attach_membership_visibility(&mut attrs, &alloc_node.membership);
     insert_def_specialization_attr(&mut attrs, alloc_node.specializes.as_deref());
@@ -1057,12 +1071,13 @@ pub(crate) fn materialize_case_def(
     parent_id: Option<&NodeId>,
     c_node: &Node<CaseDef>,
 ) {
-    let name = identification_name(&c_node.identification);
-    if name.is_empty() {
-        return;
-    }
-    let qualified = qualified_name_for_node(g, uri, container_prefix, &name, "case def");
     let mut attrs = HashMap::new();
+    let name = resolve_addressable_name(
+        &identification_name(&c_node.identification),
+        "case def",
+        &mut attrs,
+    );
+    let qualified = qualified_name_for_node(g, uri, container_prefix, &name, "case def");
     attach_short_name_attribute(&mut attrs, &c_node.identification);
     attach_membership_visibility(&mut attrs, &c_node.membership);
     insert_def_specialization_attr(&mut attrs, c_node.specializes.as_deref());
@@ -1142,12 +1157,13 @@ pub(crate) fn materialize_analysis_case_def(
     parent_id: Option<&NodeId>,
     c_node: &Node<AnalysisCaseDef>,
 ) {
-    let name = identification_name(&c_node.identification);
-    if name.is_empty() {
-        return;
-    }
-    let qualified = qualified_name_for_node(g, uri, container_prefix, &name, "analysis def");
     let mut attrs = HashMap::new();
+    let name = resolve_addressable_name(
+        &identification_name(&c_node.identification),
+        "analysis def",
+        &mut attrs,
+    );
+    let qualified = qualified_name_for_node(g, uri, container_prefix, &name, "analysis def");
     attach_short_name_attribute(&mut attrs, &c_node.identification);
     attach_membership_visibility(&mut attrs, &c_node.membership);
     insert_def_specialization_attr(&mut attrs, c_node.specializes.as_deref());
@@ -1217,12 +1233,13 @@ pub(crate) fn materialize_verification_case_def(
     parent_id: Option<&NodeId>,
     c_node: &Node<VerificationCaseDef>,
 ) {
-    let name = identification_name(&c_node.identification);
-    if name.is_empty() {
-        return;
-    }
-    let qualified = qualified_name_for_node(g, uri, container_prefix, &name, "verification def");
     let mut attrs = HashMap::new();
+    let name = resolve_addressable_name(
+        &identification_name(&c_node.identification),
+        "verification def",
+        &mut attrs,
+    );
+    let qualified = qualified_name_for_node(g, uri, container_prefix, &name, "verification def");
     attach_short_name_attribute(&mut attrs, &c_node.identification);
     attach_membership_visibility(&mut attrs, &c_node.membership);
     insert_def_specialization_attr(&mut attrs, c_node.specializes.as_deref());

--- a/crates/sysml_model/src/semantic/graph_builder/package_body/mod.rs
+++ b/crates/sysml_model/src/semantic/graph_builder/package_body/mod.rs
@@ -38,7 +38,7 @@ use super::verification;
 use super::view_def;
 use super::{
     add_node_and_recurse, attach_feature_properties, insert_def_specialization_attr,
-    qualified_name_for_node, wire_def_specialization_edge,
+    qualified_name_for_node, resolve_addressable_name, wire_def_specialization_edge,
 };
 use super::{interface_def, part_def, port_def, state, usage_builders, use_case};
 

--- a/crates/sysml_model/src/semantic/graph_builder/part_def.rs
+++ b/crates/sysml_model/src/semantic/graph_builder/part_def.rs
@@ -19,7 +19,10 @@ use super::interface_def;
 use super::port_def::materialize_port_usage;
 use super::state;
 use super::usage_builders;
-use super::{add_node_and_recurse, attach_feature_properties, qualified_name_for_node};
+use super::{
+    add_node_and_recurse, attach_feature_properties, qualified_name_for_node,
+    resolve_addressable_name,
+};
 
 pub(super) fn build_from_part_def_body_element(
     node: &sysml_v2_parser::Node<PartDefBodyElement>,
@@ -103,10 +106,14 @@ pub(super) fn build_from_part_def_body_element(
             materialize_port_usage(n, uri, container_prefix, parent_id, g);
         }
         PDBE::PartDef(pd_node) => {
-            let name = identification_name(&pd_node.identification);
+            let mut attrs = HashMap::new();
+            let name = resolve_addressable_name(
+                &identification_name(&pd_node.identification),
+                "part def",
+                &mut attrs,
+            );
             let qualified = qualified_name_for_node(g, uri, container_prefix, &name, "part def");
             let range = span_to_range(&pd_node.span);
-            let mut attrs = HashMap::new();
             attach_short_name_attribute(&mut attrs, &pd_node.identification);
             attach_membership_visibility(&mut attrs, &pd_node.membership);
             if let Some(ref p) = pd_node.definition_prefix {
@@ -162,38 +169,39 @@ pub(super) fn build_from_part_def_body_element(
             );
         }
         PDBE::ItemDef(item_node) => {
-            let name = identification_name(&item_node.identification);
-            if !name.is_empty() {
-                let qualified =
-                    qualified_name_for_node(g, uri, container_prefix, &name, "item def");
-                let mut attrs = HashMap::new();
-                attach_short_name_attribute(&mut attrs, &item_node.identification);
-                attach_membership_visibility(&mut attrs, &item_node.membership);
-                if let Some(ref s) = item_node.specializes {
-                    attrs.insert("specializes".to_string(), serde_json::json!(s));
-                }
-                add_node_and_recurse(
-                    g,
-                    uri,
-                    &qualified,
-                    "item def",
-                    name,
-                    span_to_range(&item_node.span),
-                    attrs,
-                    Some(parent_id),
-                );
-                for target in typing_targets(item_node.specializes.as_deref()) {
-                    add_specializes_edge_if_exists(g, uri, &qualified, target, container_prefix);
-                }
-                let node_id = NodeId::new(uri, &qualified);
-                attribute_body::build_from_attribute_body(
-                    &item_node.body,
-                    uri,
-                    Some(&qualified),
-                    &node_id,
-                    g,
-                );
+            let mut attrs = HashMap::new();
+            let name = resolve_addressable_name(
+                &identification_name(&item_node.identification),
+                "item def",
+                &mut attrs,
+            );
+            let qualified = qualified_name_for_node(g, uri, container_prefix, &name, "item def");
+            attach_short_name_attribute(&mut attrs, &item_node.identification);
+            attach_membership_visibility(&mut attrs, &item_node.membership);
+            if let Some(ref s) = item_node.specializes {
+                attrs.insert("specializes".to_string(), serde_json::json!(s));
             }
+            add_node_and_recurse(
+                g,
+                uri,
+                &qualified,
+                "item def",
+                name,
+                span_to_range(&item_node.span),
+                attrs,
+                Some(parent_id),
+            );
+            for target in typing_targets(item_node.specializes.as_deref()) {
+                add_specializes_edge_if_exists(g, uri, &qualified, target, container_prefix);
+            }
+            let node_id = NodeId::new(uri, &qualified);
+            attribute_body::build_from_attribute_body(
+                &item_node.body,
+                uri,
+                Some(&qualified),
+                &node_id,
+                g,
+            );
         }
         PDBE::ItemUsage(item_node) => {
             usage_builders::materialize_item_usage(item_node, uri, container_prefix, parent_id, g);

--- a/crates/sysml_model/tests/anonymous_definition_semantics.rs
+++ b/crates/sysml_model/tests/anonymous_definition_semantics.rs
@@ -1,0 +1,126 @@
+//! Anonymous definitions get kind-tagged synthetic names and stay addressable (#32).
+
+use sysml_model::{build_semantic_graph_from_documents, SysmlDocument, SysmlDocumentSourceKind};
+
+fn workspace_doc(path: &str, content: &str) -> SysmlDocument {
+    SysmlDocument::from_memory_path(
+        "workspace",
+        path,
+        content.to_string(),
+        SysmlDocumentSourceKind::Workspace,
+        None,
+        None,
+    )
+    .expect("workspace document")
+}
+
+#[test]
+fn anonymous_item_def_materializes_with_kind_tagged_name_and_nested_member() {
+    let doc = workspace_doc(
+        "anon_item.sysml",
+        r#"package P {
+  item def {
+    attribute id : String;
+  }
+}"#,
+    );
+    let (graph, _parsed) = build_semantic_graph_from_documents(&[doc]).expect("semantic graph");
+
+    let item_def = graph
+        .nodes_named("_itemDef")
+        .into_iter()
+        .find(|node| node.element_kind == "item def")
+        .expect("anonymous item def");
+    assert_eq!(item_def.id.qualified_name, "P::_itemDef");
+    assert_eq!(
+        item_def.attributes.get("isAnonymous"),
+        Some(&serde_json::json!(true))
+    );
+
+    let child = graph
+        .children_of(item_def)
+        .into_iter()
+        .find(|node| node.name == "id")
+        .expect("nested attribute on anonymous item def");
+    assert_eq!(child.parent_id.as_ref(), Some(&item_def.id));
+    assert!(
+        child.id.qualified_name.starts_with("P::_itemDef::"),
+        "nested member should inherit synthetic prefix, got {}",
+        child.id.qualified_name
+    );
+}
+
+#[test]
+fn sibling_anonymous_item_defs_get_distinct_qualified_names() {
+    let doc = workspace_doc(
+        "anon_siblings.sysml",
+        r#"package P {
+  item def { attribute a : String; }
+  item def { attribute b : String; }
+}"#,
+    );
+    let uri = doc.uri.clone();
+    let (graph, _parsed) = build_semantic_graph_from_documents(&[doc]).expect("semantic graph");
+
+    let mut anon_items: Vec<_> = graph
+        .nodes_for_uri(&uri)
+        .into_iter()
+        .filter(|n| {
+            n.element_kind == "item def"
+                && n.attributes.get("isAnonymous") == Some(&serde_json::json!(true))
+        })
+        .collect();
+    assert_eq!(anon_items.len(), 2, "expected two anonymous item defs");
+    anon_items.sort_by(|a, b| a.id.qualified_name.cmp(&b.id.qualified_name));
+
+    assert_eq!(anon_items[0].id.qualified_name, "P::_itemDef");
+    assert!(
+        anon_items[1].id.qualified_name.starts_with("P::_itemDef#"),
+        "second sibling should use #kind disambiguation, got {}",
+        anon_items[1].id.qualified_name
+    );
+
+    for item in &anon_items {
+        assert!(
+            !graph.children_of(item).is_empty(),
+            "each anonymous def should keep nested members under {}",
+            item.id.qualified_name
+        );
+    }
+}
+
+#[test]
+fn anonymous_constraint_def_and_calc_def_stay_addressable() {
+    let doc = workspace_doc(
+        "anon_constraint_calc.sysml",
+        r#"package P {
+  constraint def {
+    doc /* empty body */
+  }
+  calc def {
+    doc /* empty body */
+  }
+}"#,
+    );
+    let (graph, _parsed) = build_semantic_graph_from_documents(&[doc]).expect("semantic graph");
+
+    let constraint_def = graph
+        .nodes_named("_constraintDef")
+        .into_iter()
+        .find(|n| n.element_kind == "constraint def")
+        .expect("anonymous constraint def");
+    assert_eq!(
+        constraint_def.attributes.get("isAnonymous"),
+        Some(&serde_json::json!(true))
+    );
+
+    let calc_def = graph
+        .nodes_named("_calcDef")
+        .into_iter()
+        .find(|n| n.element_kind == "calc def")
+        .expect("anonymous calc def");
+    assert_eq!(
+        calc_def.attributes.get("isAnonymous"),
+        Some(&serde_json::json!(true))
+    );
+}


### PR DESCRIPTION
## Summary
- Assign kind-tagged synthetic names (e.g. `_itemDef`) when a def/usage has no declared name, then disambiguate siblings via existing `qualified_name_for_node`
- Stop early-returning on empty names so anonymous defs and nested members enter the graph; set `isAnonymous` on those nodes
- Add unit + integration coverage for nested members, sibling collisions, and constraint/calc defs

Closes #32

## Test plan
- [x] `cargo test -p sysml_model --test anonymous_definition_semantics`
- [x] `cargo test -p sysml_model --lib anonymous_name_tests`
- [x] `cargo clippy -p sysml_model -- -D warnings`
- [x] CI green on this PR

Made with [Cursor](https://cursor.com)