### PR TITLE
Replace bincode with postcard for the parse cache (RUSTSEC-2025-0141)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,26 +144,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
-name = "bincode"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
-dependencies = [
- "bincode_derive",
- "serde",
- "unty",
-]
-
-[[package]]
-name = "bincode_derive"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
-dependencies = [
- "virtue",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2329,12 +2309,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
-name = "unty"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
-
-[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2370,12 +2344,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "virtue"
-version = "0.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "walkdir"
@@ -2760,12 +2728,12 @@ dependencies = [
 name = "workspace"
 version = "0.50.0"
 dependencies = [
- "bincode",
  "directories",
  "dirs",
  "kpar",
  "language_service",
  "petgraph",
+ "postcard",
  "proc-macro2",
  "rayon",
  "serde",

--- a/crates/workspace/Cargo.toml
+++ b/crates/workspace/Cargo.toml
@@ -37,7 +37,7 @@ walkdir = "2"
 sysml-v2-parser = { workspace = true }
 petgraph = { workspace = true }
 tracing = "0.1"
-bincode = { version = "2", features = ["serde"] }
+postcard = { workspace = true }
 rayon = "1.12"
 tempfile = "3"
 

--- a/crates/workspace/src/library_graph_cache.rs
+++ b/crates/workspace/src/library_graph_cache.rs
@@ -14,7 +14,7 @@
 //! [magic:       4 bytes  "LGCX"]
 //! [version:    20 bytes  spec42 semver (12 bytes, zero-padded) + PARSE_AST_VERSION (4 bytes, le)
 //!                       + library-graph semantics version (4 bytes, le)]
-//! [payload:    remainder — bincode-encoded LibraryGraphCachePayload]
+//! [payload:    remainder — JSON-encoded LibraryGraphCachePayload]
 //! ```
 //!
 //! # Invalidation (two-level)

--- a/crates/workspace/src/parse_cache.rs
+++ b/crates/workspace/src/parse_cache.rs
@@ -10,11 +10,11 @@
 //!
 //! ```text
 //! [magic:   4 bytes  "KPC\0"]
-//! [version: 16 bytes spec42 semver string, zero-padded]
-//! [payload: remainder — bincode-encoded RootNamespace]
+//! [version: 20 bytes spec42 semver string, zero-padded]
+//! [payload: remainder — postcard-encoded RootNamespace]
 //! ```
 //!
-//! The 20-byte header allows fast staleness detection without decoding the tree.
+//! The 24-byte header allows fast staleness detection without decoding the tree.
 //! The version field is taken from this crate's Cargo version (shared across the
 //! whole workspace via `version.workspace = true`), so every release automatically
 //! invalidates the cache without any manual bump.
@@ -26,17 +26,22 @@ use sha2::{Digest, Sha256};
 use sysml_v2_parser::RootNamespace;
 
 const MAGIC: &[u8; 4] = b"KPC\0";
-const VERSION_FIELD_LEN: usize = 16;
+const VERSION_FIELD_LEN: usize = 20;
+// v2: switched the payload encoding from bincode (RUSTSEC-2025-0141: unmaintained) to postcard.
+// Bumping this makes a v1 (bincode) cache entry unreachable rather than misdecoded.
+const PARSE_CACHE_ENCODING_VERSION: u32 = 2;
 
 fn version_field() -> [u8; VERSION_FIELD_LEN] {
-    // First 12 bytes: spec42 semver string; last 4 bytes: PARSE_AST_VERSION (le).
-    // Incorporating the parser schema version invalidates caches when the AST
-    // schema changes between parser releases, even within a single spec42 version.
+    // First 12 bytes: spec42 semver string; next 4 bytes: PARSE_AST_VERSION (le); last 4
+    // bytes: PARSE_CACHE_ENCODING_VERSION (le). Incorporating the parser schema version and
+    // the on-disk encoding version invalidates caches when either changes, even within a
+    // single spec42 version.
     let spec42 = env!("CARGO_PKG_VERSION").as_bytes();
     let mut field = [0u8; VERSION_FIELD_LEN];
     let spec42_len = spec42.len().min(12);
     field[..spec42_len].copy_from_slice(&spec42[..spec42_len]);
     field[12..16].copy_from_slice(&sysml_v2_parser::PARSE_AST_VERSION.to_le_bytes());
+    field[16..20].copy_from_slice(&PARSE_CACHE_ENCODING_VERSION.to_le_bytes());
     field
 }
 
@@ -79,10 +84,7 @@ pub fn load(cache_dir: &Path, hash: &[u8; 32]) -> Option<RootNamespace> {
     let mut payload = Vec::new();
     file.read_to_end(&mut payload).ok()?;
 
-    let config = bincode::config::standard();
-    bincode::serde::decode_from_slice::<RootNamespace, _>(&payload, config)
-        .ok()
-        .map(|(root, _)| root)
+    postcard::from_bytes::<RootNamespace>(&payload).ok()
 }
 
 /// Write a freshly parsed [`RootNamespace`] to the cache.
@@ -133,8 +135,7 @@ fn store_inner(
 ) -> Result<(), Box<dyn std::error::Error>> {
     std::fs::create_dir_all(cache_dir)?;
 
-    let config = bincode::config::standard();
-    let payload = bincode::serde::encode_to_vec(root, config)?;
+    let payload = postcard::to_allocvec(root)?;
 
     let path = entry_path(cache_dir, hash);
     let mut file = std::fs::File::create(&path)?;
@@ -199,8 +200,7 @@ mod tests {
 
         // Write with a deliberately wrong version
         let path = entry_path(dir.path(), &hash);
-        let config = bincode::config::standard();
-        let payload = bincode::serde::encode_to_vec(&root, config).unwrap();
+        let payload = postcard::to_allocvec(&root).unwrap();
         let mut f = std::fs::File::create(&path).unwrap();
         f.write_all(MAGIC).unwrap();
         f.write_all(&[0u8; VERSION_FIELD_LEN]).unwrap(); // all-zero != any real version


### PR DESCRIPTION
## Summary

`bincode` 2.0.1 is flagged unmaintained (RUSTSEC-2025-0141), currently allowed in `cargo audit` rather than fixed. It was only actually used in `crates/workspace/src/parse_cache.rs` (the on-disk `RootNamespace` parse cache) — `library_graph_cache.rs`'s doc comment claimed bincode too, but its actual payload encoding is already `serde_json`, so only its stale comment needed correcting.

- Swapped `bincode` → `postcard` in `parse_cache.rs`. `postcard` is already a workspace dependency (used by `generator_sdk`/`generator_host` for the WASM guest-host wire format), so this reuses an already-audited, already-proven binary serde format rather than adding a new one.
- Bumped the parse-cache on-disk format version (a new `PARSE_CACHE_ENCODING_VERSION` field folded into the existing version header, following the same pattern `library_graph_cache.rs` already uses for its own semantics version) so a v1 (bincode) cache entry is cleanly unreachable rather than misdecoded, instead of relying on a coincidental future workspace version bump.
- Removed the `bincode` dependency entirely.

Closes #57.

## Test plan

- [x] `cargo test -p workspace --lib parse_cache` — all 6 tests pass (round-trip, unknown hash, wrong version, eviction, determinism)
- [x] `cargo test -p workspace` (full suite, no filter) — all green except one pre-existing, already-tracked, unrelated CRLF fixture-parsing issue ([#66](https://github.com/elan8/spec42/issues/66))
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo audit` — confirmed `bincode`'s RUSTSEC-2025-0141 warning is gone; the one remaining allowed warning (`atomic-polyfill`/RUSTSEC-2023-0089, transitively via `postcard`→`heapless`) predates this change and is unrelated to it (`postcard` was already a workspace dependency elsewhere)

🤖 Generated with [Claude Code](https://claude.com/claude-code)