### PR TITLE
Canonicalize file URI identities

### DIFF
--- a/crates/language_service/src/uri.rs
+++ b/crates/language_service/src/uri.rs
@@ -1,11 +1,17 @@
 use url::Url;
 
-/// Normalizes a document URI for consistent lookup (file URIs on Windows, etc.).
+/// Normalizes a document URI for consistent lookup.
+///
+/// Existing file paths are canonicalized so alternate filesystem spellings (for example,
+/// macOS's `/var` symlink to `/private/var`) cannot create distinct document identities.
+/// Nonexistent paths retain their lexical identity, which is required for editor buffers that
+/// have not been saved yet. Windows drive letters are normalized to lowercase in either case.
 pub fn normalize_uri(uri: &Url) -> Url {
     if uri.scheme() != "file" {
         return uri.clone();
     }
     if let Ok(path) = uri.to_file_path() {
+        let path = std::fs::canonicalize(&path).unwrap_or(path);
         if let Ok(mut normalized) = Url::from_file_path(path) {
             let p = normalized.path();
             if p.len() >= 3 {
@@ -22,6 +28,40 @@ pub fn normalize_uri(uri: &Url) -> Url {
         }
     }
     uri.clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_uri;
+    use url::Url;
+
+    #[cfg(unix)]
+    #[test]
+    fn existing_file_uris_use_the_canonical_filesystem_identity() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let real_dir = temp.path().join("real");
+        let alias_dir = temp.path().join("alias");
+        std::fs::create_dir(&real_dir).expect("real directory");
+        symlink(&real_dir, &alias_dir).expect("directory symlink");
+        let real_file = real_dir.join("Model.sysml");
+        std::fs::write(&real_file, "package Model;").expect("model");
+
+        let aliased = Url::from_file_path(alias_dir.join("Model.sysml")).expect("aliased URI");
+        let canonical = Url::from_file_path(&real_file).expect("canonical URI");
+
+        assert_eq!(normalize_uri(&aliased), normalize_uri(&canonical));
+    }
+
+    #[test]
+    fn nonexistent_file_uri_keeps_its_lexical_identity() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("Unsaved.sysml");
+        let uri = Url::from_file_path(path).expect("unsaved URI");
+
+        assert_eq!(normalize_uri(&uri), uri);
+    }
 }
 
 /// Returns true when `candidate` is under any of the library root URIs.

--- a/crates/language_service/src/uri.rs
+++ b/crates/language_service/src/uri.rs
@@ -30,6 +30,13 @@ pub fn normalize_uri(uri: &Url) -> Url {
     uri.clone()
 }
 
+/// Returns true when `candidate` is under any of the library root URIs.
+pub fn uri_under_any_library(candidate: &Url, library_paths: &[Url]) -> bool {
+    library_paths
+        .iter()
+        .any(|root| candidate.as_str().starts_with(root.as_str()))
+}
+
 #[cfg(test)]
 mod tests {
     use super::normalize_uri;
@@ -62,11 +69,4 @@ mod tests {
 
         assert_eq!(normalize_uri(&uri), uri);
     }
-}
-
-/// Returns true when `candidate` is under any of the library root URIs.
-pub fn uri_under_any_library(candidate: &Url, library_paths: &[Url]) -> bool {
-    library_paths
-        .iter()
-        .any(|root| candidate.as_str().starts_with(root.as_str()))
 }

--- a/crates/workspace/src/snapshot/discovery.rs
+++ b/crates/workspace/src/snapshot/discovery.rs
@@ -92,27 +92,7 @@ pub fn path_to_file_url(path: &Path) -> WorkspaceResult<Url> {
             canonical.display()
         ))
     })?;
-    Ok(normalize_file_url_drive_letter(url))
-}
-
-/// Lowercases the Windows drive letter in a `file://` URL (`file:///C:/...` → `file:///c:/...`).
-/// Keeps URIs consistent with those produced by `FileSystemDocumentProvider` so that
-/// semantic graph lookups by URI don't fail due to drive-letter case mismatches.
-fn normalize_file_url_drive_letter(url: Url) -> Url {
-    if url.scheme() != "file" {
-        return url;
-    }
-    let path = url.path();
-    if path.len() >= 3 {
-        let bytes = path.as_bytes();
-        if bytes[0] == b'/' && bytes[1].is_ascii_uppercase() && bytes[2] == b':' {
-            let new_path = format!("/{}{}", (bytes[1] as char).to_ascii_lowercase(), &path[2..]);
-            if let Ok(normalized) = Url::parse(&format!("file://{new_path}")) {
-                return normalized;
-            }
-        }
-    }
-    url
+    Ok(language_service::uri::normalize_uri(&url))
 }
 
 fn normalize_existing_path(path: &Path) -> WorkspaceResult<PathBuf> {


### PR DESCRIPTION
## Summary

- canonicalize existing file-backed document URIs in the shared language-service normalization owner
- preserve lexical identities for nonexistent paths used by unsaved editor buffers
- make workspace target discovery reuse the shared normalization policy instead of maintaining a duplicate implementation

## Cause

On macOS, temporary paths can be spelled through `/var` while filesystem canonicalization resolves them under `/private/var`. Snapshot target discovery canonicalized its file paths, but provider documents only normalized Windows drive-letter case. The semantic graph therefore held the expected nodes under one URI while host projection queried a different URI and returned an empty projection. This single identity mismatch caused all 22 failures in `snapshot_single_build`.

## Verification

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p language_service uri::tests`
- `cargo test -p language_service -p workspace`
- `snapshot_single_build`: 23 passed, 0 failed, 1 pre-existing intentional ignore