### PR TITLE
Fix LSP diagram view catalog provenance

### DIFF
--- a/crates/lsp_server/src/lsp_runtime/documents/startup.rs
+++ b/crates/lsp_server/src/lsp_runtime/documents/startup.rs
@@ -19,6 +19,7 @@ pub(crate) async fn initialize(
         .standard_library_paths
         .iter()
         .filter_map(|path| Url::from_file_path(path).ok())
+        .map(|uri| util::normalize_file_uri(&uri))
         .collect::<Vec<_>>();
     let startup_trace_id =
         util::parse_startup_trace_id_from_value(params.initialization_options.as_ref());

--- a/crates/lsp_server/tests/integration/diagram_views.rs
+++ b/crates/lsp_server/tests/integration/diagram_views.rs
@@ -1,0 +1,119 @@
+use std::path::{Path, PathBuf};
+
+use super::harness::TestSession;
+
+fn standard_library_fixture(root: &Path) {
+    let systems = root.join("SysML_Systems_Library-2.0.0");
+    std::fs::create_dir_all(&systems).expect("standard-library root");
+    std::fs::write(
+        systems.join("StandardViewDefinitions.sysml"),
+        concat!(
+            "standard library package StandardViewDefinitions { ",
+            "view def GeneralView; ",
+            "view def InterconnectionView; ",
+            "view def SequenceView; ",
+            "view def StateTransitionView; ",
+            "view def ActionFlowView; ",
+            "}\n",
+        ),
+    )
+    .expect("standard view definitions");
+}
+
+fn open_workspace_models(session: &mut TestSession, root: &Path) -> Vec<(String, String)> {
+    let mut models = std::fs::read_dir(root)
+        .expect("webshop fixture directory")
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.extension()
+                .is_some_and(|extension| extension == "sysml")
+        })
+        .map(|path| {
+            let uri = url::Url::from_file_path(&path)
+                .expect("model URI")
+                .to_string();
+            let text = std::fs::read_to_string(&path).expect("model source");
+            (uri, text)
+        })
+        .collect::<Vec<_>>();
+    models.sort_by(|left, right| left.0.cmp(&right.0));
+    for (uri, text) in &models {
+        session.did_open(uri, text, 1);
+    }
+    models
+}
+
+#[test]
+fn diagram_views_returns_the_webshop_catalog_over_the_lsp() {
+    let stdlib = tempfile::tempdir().expect("standard-library fixture");
+    standard_library_fixture(stdlib.path());
+    let webshop = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../examples/webshop")
+        .canonicalize()
+        .expect("webshop fixture root");
+    let views_uri = url::Url::from_file_path(webshop.join("Views.sysml"))
+        .expect("Views.sysml URI")
+        .to_string();
+
+    let mut session = TestSession::new_with_env(&[("SPEC42_LSP_TEST_STDLIB", stdlib.path())]);
+    let root_uri = url::Url::from_directory_path(&webshop).expect("workspace root URI");
+    session.initialize_with_root("diagram-views-test", &root_uri);
+    let models = open_workspace_models(&mut session, &webshop);
+    session.wait_for_publications(
+        &models
+            .iter()
+            .map(|(uri, _)| uri.as_str())
+            .collect::<Vec<_>>(),
+    );
+
+    let definition = session.request(
+        "textDocument/definition",
+        serde_json::json!({
+            "textDocument": { "uri": views_uri },
+            "position": { "line": 7, "character": 24 }
+        }),
+    );
+    assert!(
+        !definition["result"].is_null(),
+        "GeneralView must resolve through the LSP publication: {definition}"
+    );
+
+    let response = session.request(
+        "spec42/diagramViews",
+        serde_json::json!({ "modelUri": views_uri }),
+    );
+    assert!(response.get("error").is_none(), "LSP response: {response}");
+    assert_eq!(
+        response["result"]["semanticStatus"]["available"], true,
+        "LSP response: {response}"
+    );
+    let views = response["result"]["views"]
+        .as_array()
+        .unwrap_or_else(|| panic!("diagram views array: {response}"));
+    assert_eq!(views.len(), 7, "LSP response: {response}");
+
+    let mut names = views
+        .iter()
+        .filter_map(|view| view["name"].as_str())
+        .collect::<Vec<_>>();
+    names.sort_unstable();
+    assert_eq!(
+        names,
+        [
+            "checkoutFlow",
+            "checkoutPipeline",
+            "connections",
+            "orderEventFanout",
+            "orderLifecycle",
+            "requirements",
+            "structure",
+        ]
+    );
+
+    assert_eq!(
+        models.len(),
+        5,
+        "the regression must exercise the whole webshop model"
+    );
+}

--- a/crates/lsp_server/tests/integration/harness.rs
+++ b/crates/lsp_server/tests/integration/harness.rs
@@ -168,7 +168,11 @@ pub struct TestSession {
 
 impl TestSession {
     pub fn new() -> Self {
-        let mut child = spawn_server();
+        Self::new_with_env(&[])
+    }
+
+    pub fn new_with_env(env: &[(&str, &std::path::Path)]) -> Self {
+        let mut child = spawn_server_with_env(env);
         let stdin = child.stdin.take().expect("stdin");
         let stdout = child.stdout.take().expect("stdout");
         Self {
@@ -179,7 +183,11 @@ impl TestSession {
     }
 
     pub fn initialize_default(&mut self, client_name: &str) {
-        self.initialize_with_options(client_name, None);
+        self.initialize_with_root_and_options(client_name, None, None);
+    }
+
+    pub fn initialize_with_root(&mut self, client_name: &str, root_uri: &url::Url) {
+        self.initialize_with_root_and_options(client_name, Some(root_uri), None);
     }
 
     pub fn initialize_with_options(
@@ -187,10 +195,19 @@ impl TestSession {
         client_name: &str,
         initialization_options: Option<serde_json::Value>,
     ) {
+        self.initialize_with_root_and_options(client_name, None, initialization_options);
+    }
+
+    fn initialize_with_root_and_options(
+        &mut self,
+        client_name: &str,
+        root_uri: Option<&url::Url>,
+        initialization_options: Option<serde_json::Value>,
+    ) {
         let init_id = next_id();
         let mut params = serde_json::json!({
             "processId": null,
-            "rootUri": null,
+            "rootUri": root_uri,
             "capabilities": {},
             "clientInfo": { "name": client_name, "version": "0.1.0" }
         });
@@ -264,6 +281,10 @@ impl TestSession {
     /// (e.g. didOpen/didChange) are processed in-order before assertions.
     pub fn barrier(&mut self) {
         let _ = self.request("workspace/symbol", serde_json::json!({ "query": "" }));
+    }
+
+    pub fn wait_for_publications(&mut self, uris: &[&str]) {
+        wait_for_publications(&mut self.stdout, uris);
     }
 }
 

--- a/crates/lsp_server/tests/integration/mod.rs
+++ b/crates/lsp_server/tests/integration/mod.rs
@@ -10,6 +10,7 @@ mod completion;
 mod concurrency_regressions;
 mod definition;
 mod diagnostics;
+mod diagram_views;
 mod experimental_capabilities;
 mod experimental_requests;
 mod feature_inspector;


### PR DESCRIPTION
## Summary
- normalize configured standard-library file URIs at the LSP initialization boundary
- preserve `StandardLibrary` provenance on Windows so diagram view definitions remain discoverable
- add an end-to-end `spec42/diagramViews` regression covering all seven webshop views and successful `GeneralView` navigation

Fixes #93

## Verification
- `cargo test -p lsp_server --test lsp_integration diagram_views_returns_the_webshop_catalog_over_the_lsp -- --nocapture --test-threads=1`
- `cargo test -p lsp_server --lib`
- `cargo test -p lsp_server --test parse_validation`
- `cargo clippy -p lsp_server --lib --all-features -- -D warnings`
- `cargo fmt --all -- --check`

## Local limitations
- `scripts/minici.sh` could not run in the available Bash environments: WSL lacks Cargo, and Git Bash lacks Python 3/cargo-deny.
- Windows `cargo clippy -p lsp_server --all-targets --all-features -- -D warnings` reaches a pre-existing unused import in the Unix-only `common::util` test.
- The complete LSP integration run exposed the existing completion-test failures and was stopped when a later definition test did not complete; the new issue-93 regression passes independently.