### PR TITLE
fix(library_catalog): clear the target before repacking an embedded KPAR

### DIFF
--- a/crates/library_catalog/build.rs
+++ b/crates/library_catalog/build.rs
@@ -435,6 +435,21 @@ fn pack_library(entry: &LibraryEntry, source_dir: &Path, out_kpar: &Path) {
             process::exit(1);
         }
     };
+    // `build_kpar` publishes with no-force semantics (`kpar::read::ensure_absent_publish_target`),
+    // so a leftover archive -- or the empty stub `write_empty_stub` leaves when the feature is
+    // off -- from an earlier build in the same `OUT_DIR` makes an otherwise-clean rebuild abort
+    // with "refusing to replace existing publication target". Clear it first; the pack that
+    // follows is the authority for this slot.
+    if let Err(e) = fs::remove_file(out_kpar) {
+        if e.kind() != std::io::ErrorKind::NotFound {
+            eprintln!(
+                "workspace build: could not clear stale {} at {}: {e}",
+                entry.id,
+                out_kpar.display()
+            );
+            process::exit(1);
+        }
+    }
     build_kpar(&options, out_kpar).unwrap_or_else(|e| {
         eprintln!("workspace build: failed to pack {}: {e}", entry.id);
         process::exit(1);


### PR DESCRIPTION
## Problem (elan8/spec42#89)

`build_kpar` publishes with no-force semantics — `kpar::read::ensure_absent_publish_target`
refuses to replace any existing filesystem object. So once `OUT_DIR/<id>.embedded.kpar` has
been written, any rebuild that re-runs `library_catalog`'s build script aborts:

```
workspace build: failed to pack domain: invalid KPAR archive: refusing to replace existing
publication target 'target/debug/build/library_catalog-<hash>/out/domain.embedded.kpar'
```

The script re-runs on a touched `build.rs`, a changed `config/libraries/*.json`, or a changed
sibling `sysml-domain-libraries` checkout — all normal during development. Workaround was
`cargo clean -p library_catalog`.

## Fix

`pack_library` removes any leftover archive (ignoring `NotFound`) before calling `build_kpar`.
The pack that follows is the authority for that slot. The guarded bundle/cache branches in
`pack_or_copy_library` already overwrite via `fs::copy`, so only the `build_kpar` path needed
this.

## Verified

- `cargo build -p library_catalog` then `touch config/libraries/domain.json && cargo build -p library_catalog` — repeatedly — now succeeds (previously the second build aborted).
- `cargo build -p server` with the build-script rerun succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #89 