### PR TITLE
ci: move the full-tree dependency audit to nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,15 +129,41 @@ jobs:
   audit:
     name: Dependency audit
     runs-on: ubuntu-latest
+    # A RustSec advisory is a property of time, not of a diff: the unconditional full-tree audit
+    # runs nightly (`.github/workflows/nightly.yml`). Here it runs only when the push or PR
+    # actually touches a lockfile -- the case a PR author introduced and can act on.
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect lockfile changes
+        id: lock
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base='${{ github.event.pull_request.base.sha }}'
+            head='${{ github.event.pull_request.head.sha }}'
+          else
+            base='${{ github.event.before }}'
+            head='${{ github.sha }}'
+          fi
+          if [ -z "$base" ] || [ "$base" = "0000000000000000000000000000000000000000" ] \
+            || ! git cat-file -e "${base}^{commit}" 2>/dev/null; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          elif git diff --name-only "$base" "$head" | grep -qE '(^|/)Cargo\.lock$'; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Install cargo-audit
+        if: steps.lock.outputs.changed == 'true'
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-audit
 
       - name: cargo audit
+        if: steps.lock.outputs.changed == 'true'
         run: cargo audit
 
   rust-surfaces:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,6 +9,22 @@ permissions:
   contents: read
 
 jobs:
+  audit:
+    name: Dependency audit (full tree)
+    runs-on: ubuntu-latest
+    # The advisory gate: a new RustSec advisory against an existing dependency fails here rather
+    # than blocking an unrelated PR. CI's `audit` job still runs on any lockfile change.
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
+
+      - name: cargo audit
+        run: cargo audit
+
   sysml-release-validation:
     name: SysML release validation (informational)
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

`cargo audit` runs as a blocking per-PR check (`Dependency audit`). It fails whenever a new RustSec advisory is published against an existing dependency — a red X the PR author didn't cause and can't fix in their branch (e.g. PR #108, which touches zero dependency files). An advisory is a property of *time × the dependency tree*, not of a diff.

[`deny.toml`](../blob/main/deny.toml) already states CI runs only its `bans` check *"so that turning [an advisory gate] on later is a decision rather than an accident"* — the standalone `cargo audit` job is the one place that contradicts that.

## Change

- **`nightly.yml`** — new `audit` job: unconditional `cargo audit` over the whole tree, on the existing `30 22 * * *` cron. A new advisory fails here, visibly (scheduled-workflow failures notify), without blocking any PR.
- **`ci.yml`** — the `audit` job still runs on every push and PR, but only invokes `cargo audit` when a `Cargo.lock` actually changed (checked with `git diff` against the base/before SHA, no new action dependency). A PR that bumps or adds a vulnerable dependency still fails; one that doesn't touch deps passes the job trivially. The job still reports a status, so it stays valid if `Dependency audit` is a required check.

## Not changed

- `cargo deny check bans` in `minici.sh` — unaffected, still the architectural authority-ban gate.
- Dependabot — still provides the passive "vulns in our tree" alerting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
