### PR TITLE
ci: repair the red nightly run (audit, OMG 14c ratchet, fuzz)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -113,11 +113,6 @@ jobs:
           SYSML_V2_RELEASE_DIR: ${{ github.workspace }}/sysml-v2-release
         run: cargo test -p sysml_resolution unit --lib -- --nocapture
 
-      - name: OMG 14c metadata diagnostic ratchet
-        env:
-          SYSML_V2_RELEASE_DIR: ${{ github.workspace }}/sysml-v2-release
-        run: bash scripts/check-omg-14c-metadata-ratchet.sh
-
   language-and-generator-exploratory:
     name: Language and generator fuzzing (exploratory)
     runs-on: ubuntu-latest
@@ -135,6 +130,8 @@ jobs:
 
       - name: Install Rust nightly
         uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rust-src
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
@@ -149,18 +146,20 @@ jobs:
         with:
           tool: cargo-mutants
 
+      # `cargo fuzz` needs the sanitizer `-Z` flags, which are nightly-only. The repository's
+      # `rust-toolchain.toml` pins a stable channel and wins over the runner default, so every
+      # fuzz invocation has to select the nightly toolchain explicitly with `+nightly`.
       - name: Fuzz artifact path parsing
-        run: cargo fuzz run artifact_path -- -max_total_time=300 -print_final_stats=1
+        run: cargo +nightly fuzz run artifact_path -- -max_total_time=300 -print_final_stats=1
 
       - name: Fuzz ABI payload decoding
-        run: cargo fuzz run abi_decode -- -max_total_time=300 -print_final_stats=1
-
+        run: cargo +nightly fuzz run abi_decode -- -max_total_time=300 -print_final_stats=1
 
       - name: Fuzz immutable SysML publication
-        run: cargo fuzz run sysml_publication fuzz/corpus/sysml -- -max_total_time=300 -print_final_stats=1
+        run: cargo +nightly fuzz run sysml_publication fuzz/corpus/sysml -- -max_total_time=300 -print_final_stats=1
 
       - name: Fuzz SysML formatter convergence
-        run: cargo fuzz run sysml_formatter fuzz/corpus/sysml -- -max_total_time=300 -print_final_stats=1
+        run: cargo +nightly fuzz run sysml_formatter fuzz/corpus/sysml -- -max_total_time=300 -print_final_stats=1
 
       - name: Mutation-test the transaction planner
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -146,20 +146,23 @@ jobs:
         with:
           tool: cargo-mutants
 
-      # `cargo fuzz` needs the sanitizer `-Z` flags, which are nightly-only. The repository's
-      # `rust-toolchain.toml` pins a stable channel and wins over the runner default, so every
-      # fuzz invocation has to select the nightly toolchain explicitly with `+nightly`.
+      # Two things every `cargo fuzz` invocation here has to override:
+      #   * `+nightly` -- the sanitizer `-Z` flags are nightly-only, but `rust-toolchain.toml`
+      #     pins a stable channel that wins over the runner default.
+      #   * `--target x86_64-unknown-linux-gnu` -- cargo-fuzz defaults the target to the triple
+      #     it was itself built for. install-action has no cargo-fuzz binary, so it falls back to
+      #     cargo-binstall's musl build, whose static libc is incompatible with the sanitizer.
       - name: Fuzz artifact path parsing
-        run: cargo +nightly fuzz run artifact_path -- -max_total_time=300 -print_final_stats=1
+        run: cargo +nightly fuzz run --target x86_64-unknown-linux-gnu artifact_path -- -max_total_time=300 -print_final_stats=1
 
       - name: Fuzz ABI payload decoding
-        run: cargo +nightly fuzz run abi_decode -- -max_total_time=300 -print_final_stats=1
+        run: cargo +nightly fuzz run --target x86_64-unknown-linux-gnu abi_decode -- -max_total_time=300 -print_final_stats=1
 
       - name: Fuzz immutable SysML publication
-        run: cargo +nightly fuzz run sysml_publication fuzz/corpus/sysml -- -max_total_time=300 -print_final_stats=1
+        run: cargo +nightly fuzz run --target x86_64-unknown-linux-gnu sysml_publication fuzz/corpus/sysml -- -max_total_time=300 -print_final_stats=1
 
       - name: Fuzz SysML formatter convergence
-        run: cargo +nightly fuzz run sysml_formatter fuzz/corpus/sysml -- -max_total_time=300 -print_final_stats=1
+        run: cargo +nightly fuzz run --target x86_64-unknown-linux-gnu sysml_formatter fuzz/corpus/sysml -- -max_total_time=300 -print_final_stats=1
 
       - name: Mutation-test the transaction planner
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -166,6 +166,9 @@ jobs:
 
       - name: Mutation-test the transaction planner
         run: |
+          # cargo-mutants creates the final --output component but not its parents, and nothing
+          # in this job has populated target/ yet (the fuzz builds live under fuzz/target/).
+          mkdir -p target/mutants
           cargo mutants --package server --file 'src/generation/plan.rs' \
             --timeout 60 --output target/mutants
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,27 +357,27 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.134.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d552bd33b7a56dc70aeb1e1c960e51a218fa0db50f23873b500a310379450b2d"
+checksum = "16c273ba1bfc3a1cb27cb4f83df27134f3cb638a61f5ed79ab22cf86eb13da0d"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.134.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "078e80e4c222279e3330f6aa1a256ca77ddf156d4453166a9f09defedc4594dd"
+checksum = "cbf8909326a466739e83ffe11e74c0c8c6b4bfa911b612aece915daa746cff58"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.134.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "820ce15d4ad3562d613c31a67b6d0434d403e7091a68d1349903842f7d31737e"
+checksum = "3cb26b06b54d8b2f8cdf4d440a32fc3b3b91c71c162333a69a70a66fa265fc45"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -385,9 +385,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.134.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61bca563d4b86d285928d9e27f97f27039bb33a0fc524fa130d7d0c106bf8ab3"
+checksum = "7ce4e57dbb7f73d08011808a19787c3a03c3e7854b2a479ed0b788915fb671be"
 dependencies = [
  "serde",
  "serde_derive",
@@ -396,9 +396,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.134.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "709f4b7c0fb57d952658d5b5c07fbdc4149acd7b7f0de9678ae754b9c981949a"
+checksum = "74b0a8968f33d0bc13bc86fe70dd3947e93acc9f358ed9848e9988448972a9be"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -427,9 +427,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.134.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "903dc8915af62aad1d9d0f39a5968d33fa80b9aa899ed6f56e47f40ca4512e1e"
+checksum = "f69e8e2fe9deb48ef7b8d0c61612f8c1e2277d0421c201e30a4c844a4ebac698"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -440,24 +440,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.134.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0522d74c227e49f3fd49ab055311486ae4f09083262b66705bed676952491469"
+checksum = "ad4db1e87a65e9c5a832e3ede160830d4e34df938ac38b5604819f8825687e73"
 
 [[package]]
 name = "cranelift-control"
-version = "0.134.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66560ea1c5cef72e170b18e46d263dba2d3169c9d39e8cafdab2173c6362cc1a"
+checksum = "9248cd37bb6ec460981f57ead368e32b1eca7a207ad50e3e9c7adc3b161f20e9"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.134.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ef5b17cc814d27e96b66a5b46da0e4ce2b8ac55a6d478048bb99d04b05526"
+checksum = "26b8bc91c0a3530d132acbf118965dabe9a084029eb0fa74b64760360dec3316"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -467,9 +467,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.134.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a87e0aaa39dbf70693b348a221e45904111704ee8f9fef140498471005f9842d"
+checksum = "5086f2ebc084a98b387e522680f62ef65a512444d8382151e03088716d3a1714"
 dependencies = [
  "cranelift-codegen",
  "hashbrown 0.17.1",
@@ -480,15 +480,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.134.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf79003ebfa1eed5e87f3b84446ad5236f540268289960e14f387dc9b28e40b7"
+checksum = "b6a658670f779afc2df083be201ebe54805f69b7b9ffa8dab04142b72ed751c9"
 
 [[package]]
 name = "cranelift-native"
-version = "0.134.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05bf4f235743c81e67ee4db617c5a4a0b65d58d3f0cfc575ee0f1a4e0cd58273"
+checksum = "16a41083b1fd953debd6f32d21fcda765b258f323ce907fdd6b4715f2769c478"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -497,9 +497,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.134.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6977c2a71ab1e0d1e62f966b411a498aa04c4dce47d93d52f8a360a06058922"
+checksum = "244d9cd0759b0a3ccdd587cafb13434f9ea43b5c9d07701d277daf5cd0f7b7c1"
 
 [[package]]
 name = "crc32fast"
@@ -1580,9 +1580,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5c8c21ea032e4efbdf2d067dc45171779dbe0c8ecf20ef4a57efa7474f2b0a"
+checksum = "ed2bd641cb6a3ec5bffe60405568933163e0ea619da0943e9d2a417ceaa7fe82"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -1592,9 +1592,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f10925455d5dde962e3604eade797ba5488644c8ee14a44191e2f2b58980574"
+checksum = "d3fd4024d1e559eaf5579bc8ad84a2b5915f34b47acc13a06ffba7dac401b166"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2711,9 +2711,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c80ca6098e0d4d06886d91d7f2cc3cb6623eb583c4c0ab3c89cbfb6098c8586c"
+checksum = "4cdaf5b8af5713146e3a62d940c71e3eb2ad1ebacfa6b55f0c8509a5b4b87718"
 dependencies = [
  "addr2line",
  "async-trait",
@@ -2750,9 +2750,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134f9d136d29c76f6c1b4c9b468e97a2efc38c7d49fd188e39b64870b2fea701"
+checksum = "58793271eab7ec26bab99ca497131f8b37702e7dc39e2f2d18293e3e915b4964"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -2781,9 +2781,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65db2eb1bfc5371a3b4107dbf539d0b93d05016fc29625b1648146b47db02071"
+checksum = "ede02ba77442cab88a2ddd5d16373e8bc450b55e05de8be039b024987a53d5a7"
 dependencies = [
  "base64",
  "directories-next",
@@ -2801,15 +2801,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc8a678149885cae00289f806fbe74c7863084cf74cace0b8dc73602279400e1"
+checksum = "3d7032ff6b4d7a45e05be1cb32ec1756df5f2669f08296dbe2c61c3789dead2c"
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0092c4b9d070ac5e278b6d0db10f5e71214190f0347ca57502b4692f796321"
+checksum = "f41d3b2cb9c3de7b696690af070d408b5e357011832f8b8bb7fbb315dbb620ed"
 dependencies = [
  "hashbrown 0.17.1",
  "libm",
@@ -2818,9 +2818,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6851ebc9e03cab23d9821d2b2505d380bdfe38f35ccec945247b05274d85c98b"
+checksum = "1d5cda5b90247978dd2ba6ca4e309508da19e9244445671d2d0e6a34e5c3b847"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -2845,9 +2845,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b26da6d5f60d4c438da70bba3553fe810a840533a64156be287dca2081c6991"
+checksum = "4d126366176553e8f304e8ac2078a4cc37134fe8f19d4d4695a09c5a2f577f10"
 dependencies = [
  "cc",
  "cfg-if",
@@ -2860,9 +2860,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed621ba25d7bf78b7edd7b4749abbb27c2e5cdba836c9504a424ee74b6c23149"
+checksum = "c1d28ff131bc40e11d84bc3a9fa0d264506439ffbbc89f3562fbb529d1caa617"
 dependencies = [
  "cc",
  "wasmtime-internal-versioned-export-macros",
@@ -2870,9 +2870,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5684ba160951baad06a725696f3c590e2fb0e8067c2aebee27bf7f9259058e85"
+checksum = "4a52de8b6afbfcd618073f592c1450cb661574e7061f3f4a44f1f7ec0c7f7909"
 dependencies = [
  "cfg-if",
  "libc",
@@ -2882,9 +2882,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112eead527bffa8ff0646a11fb4339a9d52ddd1da2b9a6fce4aff84c815dd94f"
+checksum = "5524fbaaf3d2134dd6229164d7fc81e443cce06d1e0576524d5f4e86e747cb13"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -2895,9 +2895,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "153592e0bed824fc13c6696203fa1bd7bd20eb355316475e39a55f081ef80eca"
+checksum = "e93bb9ae112a80618510f938275a5d88637b656e7d0a021fc906f52206c708ad"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2948,7 +2948,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Nightly run [33458299489](https://github.com/elan8/spec42/actions/runs/33458299489) had three independent failures. This greens all three.

### 1. `Dependency audit (full tree)` — `cargo audit` exit 1

`wasmtime 47.0.3` picked up two advisories dated 2026-08-20:

| Advisory | Title | Severity |
| --- | --- | --- |
| RUSTSEC-2026-0269 | Filesystem sandbox escape when paths or symlinks contain trailing slashes | 8.8 high |
| RUSTSEC-2026-0268 | Guest controlled-size host heap allocation through WASIp3 streams | — |

Both fixed in `47.0.4`, a patch release inside the existing `wasmtime = "47"` requirement in `crates/generator_host`. Lockfile-only bump (`cargo update -p wasmtime --precise 47.0.4`). `cargo audit` now exits 0; `cargo check -p generator_host` passes.

### 2. `SysML release validation` → `OMG 14c metadata diagnostic ratchet` — exit 127

`bash: scripts/check-omg-14c-metadata-ratchet.sh: No such file or directory`. The script, its budget file, and its fixtures were deleted in b828af15e (*refactor: remove legacy semantic graph*) together with the `semantic_core` crate, but this workflow step was left behind. Removed the orphaned step.

### 3. `Language and generator fuzzing` → `Fuzz artifact path parsing` — exit 1

`error: the option 'Z' is only accepted on the nightly compiler`. `cargo fuzz` needs nightly-only sanitizer `-Z` flags, but `rust-toolchain.toml` pins a stable channel that overrides the runner default. Fixed by invoking the four fuzz targets as `cargo +nightly fuzz run …` and adding the `rust-src` component that cargo-fuzz's default `-Zbuild-std` needs.

## Notes

- Jobs 2 and 3 are `continue-on-error: true` (advisory), so they never blocked required CI — but they've been red every night since their respective regressions.
- `scripts/minici.sh` not run here: it needs the pinned library bundles prepared (no network fetch) which aren't available in this environment. Changes are a lockfile patch bump + workflow-only edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)