### PR TITLE
fix(check): directed port items are not composite subparts (#105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **Directed flow items in a `port def` / `port` no longer trip `port_owned_usage_composite`.**
+  `in item rx : Signal;` / `out item tx : Signal;` are flow-feature declarations, not composite
+  subparts: a feature direction makes the usage referential (the Pilot's `isReferenceDefault`),
+  so `validatePortDefinitionOwnedUsagesNotComposite` (8.3.12.5) and
+  `validatePortUsageNestedUsagesNotComposite` (8.3.12.6) now skip them. Only undirected composite
+  usages (`part owned : Component;`) inside a port still report. Fixes #105.
+
 - **Metadata-prefixed dependencies lower in definition bodies.** `#refinement dependency X to Y;`
   in a `requirement def`, `action def`, or `part def` body no longer reports the `#refinement`
   prefix as an `unsupported_*_definition_member`. The dependency lowers with resolved

--- a/crates/sysml_resolution/src/check/structural.rs
+++ b/crates/sysml_resolution/src/check/structural.rs
@@ -300,6 +300,11 @@ impl<D> SemanticModel<D> {
     /// and `end` make it referential, an attribute or enumeration usage is always referential
     /// (`AttributeUsage` sets `isComposite = false`), and a `ReferenceUsage` is referential by
     /// its metaclass. KerML features are composite only when authored `composite`.
+    ///
+    /// A feature direction (`in` / `out` / `inout`) also makes the usage referential: the Pilot's
+    /// `isReferenceDefault` treats every directed feature as a reference (which is why a
+    /// `ParameterUsage` above is always non-composite), so `in item rx : Signal;` inside a `port
+    /// def` is a flow feature declaration, not an owned composite subpart.
     pub(crate) fn usage_is_composite(&self, declaration: DeclarationId) -> bool {
         let Some(kind) = self.kind_of(declaration) else {
             return false;
@@ -323,7 +328,10 @@ impl<D> SemanticModel<D> {
         ) {
             return false;
         }
-        !facts.modifiers.reference && !facts.modifiers.end && !self.is_end_feature(declaration)
+        !facts.modifiers.reference
+            && !facts.modifiers.end
+            && !self.is_end_feature(declaration)
+            && facts.direction.is_none()
     }
 
     /// Appends every structural feature-conformance diagnostic authored in `document`.

--- a/tests/snapshots/sysml/examples/item_test.md
+++ b/tests/snapshots/sysml/examples/item_test.md
@@ -34,18 +34,6 @@ package ItemTest {
 (fixture-diagnostics
   (document "memory://snapshot/item_test.md"
     (diagnostics
-      (diagnostic
-        (severity warning)
-        (code "port_owned_usage_composite")
-        (source "semantic")
-        (range (start 18 2) (end 18 16))
-      )
-      (diagnostic
-        (severity warning)
-        (code "port_owned_usage_composite")
-        (source "semantic")
-        (range (start 19 2) (end 19 17))
-      )
     )
   )
 )

--- a/tests/snapshots/sysml/examples/sys_ml_v2_spec_annex_a_simple_vehicle_model.md
+++ b/tests/snapshots/sysml/examples/sys_ml_v2_spec_annex_a_simple_vehicle_model.md
@@ -1815,48 +1815,6 @@ package SimpleVehicleModel{
       )
       (diagnostic
         (severity warning)
-        (code "port_owned_usage_composite")
-        (source "semantic")
-        (range (start 225 16) (end 225 48))
-      )
-      (diagnostic
-        (severity warning)
-        (code "port_owned_usage_composite")
-        (source "semantic")
-        (range (start 230 16) (end 230 38))
-      )
-      (diagnostic
-        (severity warning)
-        (code "port_owned_usage_composite")
-        (source "semantic")
-        (range (start 233 16) (end 233 57))
-      )
-      (diagnostic
-        (severity warning)
-        (code "port_owned_usage_composite")
-        (source "semantic")
-        (range (start 236 16) (end 236 35))
-      )
-      (diagnostic
-        (severity warning)
-        (code "port_owned_usage_composite")
-        (source "semantic")
-        (range (start 274 16) (end 274 48))
-      )
-      (diagnostic
-        (severity warning)
-        (code "port_owned_usage_composite")
-        (source "semantic")
-        (range (start 277 16) (end 277 67))
-      )
-      (diagnostic
-        (severity warning)
-        (code "port_owned_usage_composite")
-        (source "semantic")
-        (range (start 278 16) (end 278 57))
-      )
-      (diagnostic
-        (severity warning)
         (code "unresolved_type_reference")
         (source "semantic")
         (range (start 283 40) (end 283 44))
@@ -2286,12 +2244,6 @@ package SimpleVehicleModel{
         (code "unresolved_reference")
         (source "semantic")
         (range (start 556 56) (end 556 59))
-      )
-      (diagnostic
-        (severity warning)
-        (code "port_nested_usage_composite")
-        (source "semantic")
-        (range (start 561 24) (end 561 57))
       )
       (diagnostic
         (severity error)

--- a/tests/snapshots/sysml/examples/vehicle_analysis_demo.md
+++ b/tests/snapshots/sysml/examples/vehicle_analysis_demo.md
@@ -443,12 +443,6 @@ package 'Vehicle Analysis Demo' {
       )
       (diagnostic
         (severity warning)
-        (code "port_owned_usage_composite")
-        (source "semantic")
-        (range (start 34 9) (end 34 29))
-      )
-      (diagnostic
-        (severity warning)
         (code "unresolved_type_reference")
         (source "semantic")
         (range (start 38 31) (end 38 42))
@@ -515,12 +509,6 @@ package 'Vehicle Analysis Demo' {
       )
       (diagnostic
         (severity warning)
-        (code "port_nested_usage_composite")
-        (source "semantic")
-        (range (start 65 13) (end 65 30))
-      )
-      (diagnostic
-        (severity warning)
         (code "redefinition_direction_mismatch")
         (source "semantic")
         (range (start 65 25) (end 65 29))
@@ -530,12 +518,6 @@ package 'Vehicle Analysis Demo' {
             (range (start 34 9) (end 34 29))
           )
         )
-      )
-      (diagnostic
-        (severity warning)
-        (code "port_nested_usage_composite")
-        (source "semantic")
-        (range (start 70 17) (end 70 34))
       )
       (diagnostic
         (severity warning)

--- a/tests/snapshots/sysml/training/10_port_conjugation_example.md
+++ b/tests/snapshots/sysml/training/10_port_conjugation_example.md
@@ -32,18 +32,6 @@ package 'Port Conjugation Example' {
   (document "memory://snapshot/10_port_conjugation_example.md"
     (diagnostics
       (diagnostic
-        (severity warning)
-        (code "port_owned_usage_composite")
-        (source "semantic")
-        (range (start 8 2) (end 8 29))
-      )
-      (diagnostic
-        (severity warning)
-        (code "port_owned_usage_composite")
-        (source "semantic")
-        (range (start 9 2) (end 9 28))
-      )
-      (diagnostic
         (severity information)
         (code "unconnected_port")
         (source "semantic")

--- a/tests/snapshots/sysml/training/10_port_example.md
+++ b/tests/snapshots/sysml/training/10_port_example.md
@@ -38,30 +38,6 @@ package 'Port Example' {
   (document "memory://snapshot/10_port_example.md"
     (diagnostics
       (diagnostic
-        (severity warning)
-        (code "port_owned_usage_composite")
-        (source "semantic")
-        (range (start 8 2) (end 8 29))
-      )
-      (diagnostic
-        (severity warning)
-        (code "port_owned_usage_composite")
-        (source "semantic")
-        (range (start 9 2) (end 9 28))
-      )
-      (diagnostic
-        (severity warning)
-        (code "port_owned_usage_composite")
-        (source "semantic")
-        (range (start 14 2) (end 14 28))
-      )
-      (diagnostic
-        (severity warning)
-        (code "port_owned_usage_composite")
-        (source "semantic")
-        (range (start 15 2) (end 15 29))
-      )
-      (diagnostic
         (severity information)
         (code "unconnected_port")
         (source "semantic")

--- a/tests/snapshots/sysml/training/12_binding_connectors_example_1.md
+++ b/tests/snapshots/sysml/training/12_binding_connectors_example_1.md
@@ -66,21 +66,9 @@ package 'Binding Connectors Example-1' {
       )
       (diagnostic
         (severity warning)
-        (code "port_nested_usage_composite")
-        (source "semantic")
-        (range (start 10 4) (end 10 34))
-      )
-      (diagnostic
-        (severity warning)
         (code "unresolved_reference")
         (source "semantic")
         (range (start 10 23) (end 10 33))
-      )
-      (diagnostic
-        (severity warning)
-        (code "port_nested_usage_composite")
-        (source "semantic")
-        (range (start 11 4) (end 11 33))
       )
       (diagnostic
         (severity warning)

--- a/tests/snapshots/sysml/training/12_binding_connectors_example_2.md
+++ b/tests/snapshots/sysml/training/12_binding_connectors_example_2.md
@@ -63,21 +63,9 @@ package 'Binding Connectors Example-2' {
       )
       (diagnostic
         (severity warning)
-        (code "port_nested_usage_composite")
-        (source "semantic")
-        (range (start 10 4) (end 10 34))
-      )
-      (diagnostic
-        (severity warning)
         (code "unresolved_reference")
         (source "semantic")
         (range (start 10 23) (end 10 33))
-      )
-      (diagnostic
-        (severity warning)
-        (code "port_nested_usage_composite")
-        (source "semantic")
-        (range (start 11 4) (end 11 33))
       )
       (diagnostic
         (severity warning)

--- a/tests/snapshots/sysml/validation/3d_function_based_behavior_item.md
+++ b/tests/snapshots/sysml/validation/3d_function_based_behavior_item.md
@@ -107,12 +107,6 @@ package '3d-Function-based Behavior-item' {
         (range (start 1 16) (end 1 34))
       )
       (diagnostic
-        (severity warning)
-        (code "port_owned_usage_composite")
-        (source "semantic")
-        (range (start 10 3) (end 10 23))
-      )
-      (diagnostic
         (severity information)
         (code "unconnected_port")
         (source "semantic")

--- a/tests/snapshots/validation/sysml_port_definition_owned_usages_not_composite.md
+++ b/tests/snapshots/validation/sysml_port_definition_owned_usages_not_composite.md
@@ -14,10 +14,19 @@ type=file
 ~~~sysml
 package Ports {
     part def Component;
+    item def Signal;
 
     // Conforming: the non-port members of the port definition are referential.
     port def Good {
         attribute reading;
+    }
+
+    // Conforming: directed items are flow features, not composite subparts
+    // (Pilot `isReferenceDefault` treats every directed feature as a reference).
+    port def Directed {
+        in item rx : Signal;
+        out item tx : Signal;
+        inout item status : Signal;
     }
 
     // Invalid: a composite part usage member of a port definition.
@@ -35,7 +44,7 @@ package Ports {
         (severity warning)
         (code "port_owned_usage_composite")
         (source "semantic")
-        (range (start 10 8) (end 10 31))
+        (range (start 19 8) (end 19 31))
       )
     )
   )
@@ -50,7 +59,7 @@ package Ports {
         (severity warning)
         (code "port_owned_usage_composite")
         (source "semantic")
-        (range (start 10 8) (end 10 31))
+        (range (start 19 8) (end 19 31))
       )
     )
   )
@@ -59,23 +68,43 @@ package Ports {
 # SMG
 ~~~sexpr
 (semantic-model
-  (publication (phase resolved) (completeness complete) (has-evaluation false) (source-digest "blake3:5540e3a20a362ce258e71607914063746b85a8bfd6898ce9ee69f6257cb8ee90"))
+  (publication (phase resolved) (completeness complete) (has-evaluation false) (source-digest "blake3:ee9aac67c049c718739699dcca124cab1678c756a4ac2500617382d9cb9e62ab"))
   (declarations
     (declaration (id (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports"))) (kind package) (membership (kind owning) (visibility default)))
     (declaration (id (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Bad"))) (kind port-def) (membership (kind owning) (visibility default)))
     (declaration (id (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Bad::owned"))) (kind part) (membership (kind feature) (visibility default)) (authored (membership (kind feature) (visibility default)) (relationships (featureTyping (reference "Component")))))
     (declaration (id (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Component"))) (kind part-def) (membership (kind owning) (visibility default)))
+    (declaration (id (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Directed"))) (kind port-def) (membership (kind owning) (visibility default)))
+    (declaration (id (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Directed::rx"))) (kind item) (membership (kind feature) (visibility default)) (facts (direction in)) (authored (membership (kind feature) (visibility default)) (relationships (featureTyping (reference "Signal")))))
+    (declaration (id (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Directed::status"))) (kind item) (membership (kind feature) (visibility default)) (facts (direction inout)) (authored (membership (kind feature) (visibility default)) (relationships (featureTyping (reference "Signal")))))
+    (declaration (id (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Directed::tx"))) (kind item) (membership (kind feature) (visibility default)) (facts (direction out)) (authored (membership (kind feature) (visibility default)) (relationships (featureTyping (reference "Signal")))))
     (declaration (id (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Good"))) (kind port-def) (membership (kind owning) (visibility default)))
     (declaration (id (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Good::reading"))) (kind attribute) (membership (kind feature) (visibility default)))
+    (declaration (id (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Signal"))) (kind item-def) (membership (kind owning) (visibility default)))
   )
   (references
     (reference (id (source (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Bad::owned"))) (kind featureTyping) (ordinal 0))
       (authored-target "Component")
       (outcome (status resolved) (target (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Component")))))
+    (reference (id (source (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Directed::rx"))) (kind featureTyping) (ordinal 0))
+      (authored-target "Signal")
+      (outcome (status resolved) (target (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Signal")))))
+    (reference (id (source (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Directed::status"))) (kind featureTyping) (ordinal 0))
+      (authored-target "Signal")
+      (outcome (status resolved) (target (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Signal")))))
+    (reference (id (source (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Directed::tx"))) (kind featureTyping) (ordinal 0))
+      (authored-target "Signal")
+      (outcome (status resolved) (target (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Signal")))))
   )
   (relationships
     (relationship (kind typing) (source (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Bad::owned"))) (target (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Component"))) (provenance authored) (authored-reference (source (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Bad::owned"))) (kind featureTyping) (ordinal 0)))
+    (relationship (kind typing) (source (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Directed::rx"))) (target (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Signal"))) (provenance authored) (authored-reference (source (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Directed::rx"))) (kind featureTyping) (ordinal 0)))
+    (relationship (kind typing) (source (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Directed::status"))) (target (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Signal"))) (provenance authored) (authored-reference (source (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Directed::status"))) (kind featureTyping) (ordinal 0)))
+    (relationship (kind typing) (source (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Directed::tx"))) (target (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Signal"))) (provenance authored) (authored-reference (source (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Directed::tx"))) (kind featureTyping) (ordinal 0)))
     (relationship (kind typeFeaturing) (source (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Bad::owned"))) (target (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Bad"))) (provenance implied))
+    (relationship (kind typeFeaturing) (source (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Directed::rx"))) (target (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Directed"))) (provenance implied))
+    (relationship (kind typeFeaturing) (source (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Directed::status"))) (target (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Directed"))) (provenance implied))
+    (relationship (kind typeFeaturing) (source (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Directed::tx"))) (target (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Directed"))) (provenance implied))
     (relationship (kind typeFeaturing) (source (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Good::reading"))) (target (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Good"))) (provenance implied))
   )
   (evaluation
@@ -94,17 +123,55 @@ package Ports {
     (declaration (id (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Component")))
       (subtype (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Bad::owned")) (scopes any))
     )
+    (declaration (id (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Directed::rx")))
+      (featured-by (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Directed")))
+      (type (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Signal")) (provenance authored))
+      (effective-type (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Signal")) (source direct))
+      (supertype (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Signal")) (scopes any))
+    )
+    (declaration (id (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Directed::status")))
+      (featured-by (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Directed")))
+      (type (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Signal")) (provenance authored))
+      (effective-type (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Signal")) (source direct))
+      (supertype (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Signal")) (scopes any))
+    )
+    (declaration (id (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Directed::tx")))
+      (featured-by (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Directed")))
+      (type (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Signal")) (provenance authored))
+      (effective-type (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Signal")) (source direct))
+      (supertype (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Signal")) (scopes any))
+    )
     (declaration (id (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Good::reading")))
       (featured-by (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Good")))
+    )
+    (declaration (id (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Signal")))
+      (subtype (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Directed::rx")) (scopes any))
+      (subtype (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Directed::status")) (scopes any))
+      (subtype (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Directed::tx")) (scopes any))
     )
 )
 ~~~
 # NAVIGATION
 ~~~sexpr
 (navigation
-  (query (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (range (start 10 21) (end 10 30)) (probe (position 10 21))
+  (query (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (range (start 19 21) (end 19 30)) (probe (position 19 21))
     (reference (id (source (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Bad::owned"))) (kind featureTyping) (ordinal 0) (authored-target "Component")
       (outcome (status resolved) (target (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Component")))))
+    )
+  )
+  (query (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (range (start 12 21) (end 12 27)) (probe (position 12 21))
+    (reference (id (source (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Directed::rx"))) (kind featureTyping) (ordinal 0) (authored-target "Signal")
+      (outcome (status resolved) (target (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Signal")))))
+    )
+  )
+  (query (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (range (start 14 28) (end 14 34)) (probe (position 14 28))
+    (reference (id (source (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Directed::status"))) (kind featureTyping) (ordinal 0) (authored-target "Signal")
+      (outcome (status resolved) (target (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Signal")))))
+    )
+  )
+  (query (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (range (start 13 22) (end 13 28)) (probe (position 13 22))
+    (reference (id (source (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Directed::tx"))) (kind featureTyping) (ordinal 0) (authored-target "Signal")
+      (outcome (status resolved) (target (node (document "memory://snapshot/sysml_port_definition_owned_usages_not_composite.md") (qualified-name "Ports::Signal")))))
     )
   )
 )

--- a/tests/snapshots/validation/sysml_port_usage_nested_usages_not_composite.md
+++ b/tests/snapshots/validation/sysml_port_usage_nested_usages_not_composite.md
@@ -15,10 +15,17 @@ type=file
 package Ports {
     part def Component;
     port def Signal;
+    item def Message;
     part def Holder {
         // Conforming: the nested members of the port usage are referential.
         port good : Signal {
             attribute reading;
+        }
+
+        // Conforming: a directed item nested in a port usage is a flow feature.
+        port directed : Signal {
+            in item rx : Message;
+            out item tx : Message;
         }
 
         // Invalid: a composite part usage nested in a port usage.
@@ -37,19 +44,25 @@ package Ports {
         (severity information)
         (code "unconnected_port")
         (source "semantic")
-        (range (start 5 8) (end 7 9))
+        (range (start 6 8) (end 8 9))
       )
       (diagnostic
         (severity information)
         (code "unconnected_port")
         (source "semantic")
-        (range (start 10 8) (end 12 9))
+        (range (start 11 8) (end 14 9))
+      )
+      (diagnostic
+        (severity information)
+        (code "unconnected_port")
+        (source "semantic")
+        (range (start 17 8) (end 19 9))
       )
       (diagnostic
         (severity warning)
         (code "port_nested_usage_composite")
         (source "semantic")
-        (range (start 11 12) (end 11 35))
+        (range (start 18 12) (end 18 35))
       )
     )
   )
@@ -64,19 +77,25 @@ package Ports {
         (severity information)
         (code "unconnected_port")
         (source "semantic")
-        (range (start 5 8) (end 7 9))
+        (range (start 6 8) (end 8 9))
       )
       (diagnostic
         (severity information)
         (code "unconnected_port")
         (source "semantic")
-        (range (start 10 8) (end 12 9))
+        (range (start 11 8) (end 14 9))
+      )
+      (diagnostic
+        (severity information)
+        (code "unconnected_port")
+        (source "semantic")
+        (range (start 17 8) (end 19 9))
       )
       (diagnostic
         (severity warning)
         (code "port_nested_usage_composite")
         (source "semantic")
-        (range (start 11 12) (end 11 35))
+        (range (start 18 12) (end 18 35))
       )
     )
   )
@@ -85,15 +104,19 @@ package Ports {
 # SMG
 ~~~sexpr
 (semantic-model
-  (publication (phase resolved) (completeness complete) (has-evaluation false) (source-digest "blake3:633263db47c0a5fd62ce0e9618f1be2f3356b8c13d365fe1057d8f7347c25b0d"))
+  (publication (phase resolved) (completeness complete) (has-evaluation false) (source-digest "blake3:9ecb70e46b115c0ca5aab1e924065ea622af814d39d51dfc61ac68deca6ea9ca"))
   (declarations
     (declaration (id (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports"))) (kind package) (membership (kind owning) (visibility default)))
     (declaration (id (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Component"))) (kind part-def) (membership (kind owning) (visibility default)))
     (declaration (id (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder"))) (kind part-def) (membership (kind owning) (visibility default)))
     (declaration (id (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::bad"))) (kind port) (membership (kind feature) (visibility default)) (authored (membership (kind feature) (visibility default)) (relationships (featureTyping (reference "Signal")))))
     (declaration (id (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::bad::owned"))) (kind part) (membership (kind feature) (visibility default)) (authored (membership (kind feature) (visibility default)) (relationships (featureTyping (reference "Component")))))
+    (declaration (id (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::directed"))) (kind port) (membership (kind feature) (visibility default)) (authored (membership (kind feature) (visibility default)) (relationships (featureTyping (reference "Signal")))))
+    (declaration (id (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::directed::rx"))) (kind item) (membership (kind feature) (visibility default)) (facts (direction in)) (authored (membership (kind feature) (visibility default)) (relationships (featureTyping (reference "Message")))))
+    (declaration (id (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::directed::tx"))) (kind item) (membership (kind feature) (visibility default)) (facts (direction out)) (authored (membership (kind feature) (visibility default)) (relationships (featureTyping (reference "Message")))))
     (declaration (id (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::good"))) (kind port) (membership (kind feature) (visibility default)) (authored (membership (kind feature) (visibility default)) (relationships (featureTyping (reference "Signal")))))
     (declaration (id (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::good::reading"))) (kind attribute) (membership (kind feature) (visibility default)))
+    (declaration (id (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Message"))) (kind item-def) (membership (kind owning) (visibility default)))
     (declaration (id (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Signal"))) (kind port-def) (membership (kind owning) (visibility default)))
   )
   (references
@@ -103,6 +126,15 @@ package Ports {
     (reference (id (source (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::bad::owned"))) (kind featureTyping) (ordinal 0))
       (authored-target "Component")
       (outcome (status resolved) (target (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Component")))))
+    (reference (id (source (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::directed"))) (kind featureTyping) (ordinal 0))
+      (authored-target "Signal")
+      (outcome (status resolved) (target (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Signal")))))
+    (reference (id (source (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::directed::rx"))) (kind featureTyping) (ordinal 0))
+      (authored-target "Message")
+      (outcome (status resolved) (target (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Message")))))
+    (reference (id (source (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::directed::tx"))) (kind featureTyping) (ordinal 0))
+      (authored-target "Message")
+      (outcome (status resolved) (target (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Message")))))
     (reference (id (source (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::good"))) (kind featureTyping) (ordinal 0))
       (authored-target "Signal")
       (outcome (status resolved) (target (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Signal")))))
@@ -110,9 +142,15 @@ package Ports {
   (relationships
     (relationship (kind typing) (source (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::bad"))) (target (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Signal"))) (provenance authored) (authored-reference (source (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::bad"))) (kind featureTyping) (ordinal 0)))
     (relationship (kind typing) (source (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::bad::owned"))) (target (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Component"))) (provenance authored) (authored-reference (source (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::bad::owned"))) (kind featureTyping) (ordinal 0)))
+    (relationship (kind typing) (source (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::directed"))) (target (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Signal"))) (provenance authored) (authored-reference (source (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::directed"))) (kind featureTyping) (ordinal 0)))
+    (relationship (kind typing) (source (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::directed::rx"))) (target (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Message"))) (provenance authored) (authored-reference (source (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::directed::rx"))) (kind featureTyping) (ordinal 0)))
+    (relationship (kind typing) (source (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::directed::tx"))) (target (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Message"))) (provenance authored) (authored-reference (source (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::directed::tx"))) (kind featureTyping) (ordinal 0)))
     (relationship (kind typing) (source (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::good"))) (target (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Signal"))) (provenance authored) (authored-reference (source (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::good"))) (kind featureTyping) (ordinal 0)))
     (relationship (kind typeFeaturing) (source (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::bad"))) (target (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder"))) (provenance implied))
     (relationship (kind typeFeaturing) (source (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::bad::owned"))) (target (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::bad"))) (provenance implied))
+    (relationship (kind typeFeaturing) (source (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::directed"))) (target (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder"))) (provenance implied))
+    (relationship (kind typeFeaturing) (source (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::directed::rx"))) (target (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::directed"))) (provenance implied))
+    (relationship (kind typeFeaturing) (source (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::directed::tx"))) (target (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::directed"))) (provenance implied))
     (relationship (kind typeFeaturing) (source (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::good"))) (target (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder"))) (provenance implied))
     (relationship (kind typeFeaturing) (source (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::good::reading"))) (target (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::good"))) (provenance implied))
   )
@@ -138,6 +176,24 @@ package Ports {
       (effective-type (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Component")) (source direct))
       (supertype (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Component")) (scopes any))
     )
+    (declaration (id (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::directed")))
+      (featured-by (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder")))
+      (type (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Signal")) (provenance authored))
+      (effective-type (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Signal")) (source direct))
+      (supertype (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Signal")) (scopes any))
+    )
+    (declaration (id (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::directed::rx")))
+      (featured-by (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::directed")))
+      (type (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Message")) (provenance authored))
+      (effective-type (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Message")) (source direct))
+      (supertype (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Message")) (scopes any))
+    )
+    (declaration (id (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::directed::tx")))
+      (featured-by (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::directed")))
+      (type (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Message")) (provenance authored))
+      (effective-type (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Message")) (source direct))
+      (supertype (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Message")) (scopes any))
+    )
     (declaration (id (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::good")))
       (featured-by (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder")))
       (type (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Signal")) (provenance authored))
@@ -147,8 +203,13 @@ package Ports {
     (declaration (id (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::good::reading")))
       (featured-by (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::good")))
     )
+    (declaration (id (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Message")))
+      (subtype (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::directed::rx")) (scopes any))
+      (subtype (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::directed::tx")) (scopes any))
+    )
     (declaration (id (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Signal")))
       (subtype (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::bad")) (scopes any))
+      (subtype (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::directed")) (scopes any))
       (subtype (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::good")) (scopes any))
     )
 )
@@ -156,17 +217,32 @@ package Ports {
 # NAVIGATION
 ~~~sexpr
 (navigation
-  (query (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (range (start 10 19) (end 10 25)) (probe (position 10 19))
+  (query (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (range (start 17 19) (end 17 25)) (probe (position 17 19))
     (reference (id (source (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::bad"))) (kind featureTyping) (ordinal 0) (authored-target "Signal")
       (outcome (status resolved) (target (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Signal")))))
     )
   )
-  (query (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (range (start 11 25) (end 11 34)) (probe (position 11 25))
+  (query (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (range (start 18 25) (end 18 34)) (probe (position 18 25))
     (reference (id (source (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::bad::owned"))) (kind featureTyping) (ordinal 0) (authored-target "Component")
       (outcome (status resolved) (target (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Component")))))
     )
   )
-  (query (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (range (start 5 20) (end 5 26)) (probe (position 5 20))
+  (query (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (range (start 11 24) (end 11 30)) (probe (position 11 24))
+    (reference (id (source (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::directed"))) (kind featureTyping) (ordinal 0) (authored-target "Signal")
+      (outcome (status resolved) (target (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Signal")))))
+    )
+  )
+  (query (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (range (start 12 25) (end 12 32)) (probe (position 12 25))
+    (reference (id (source (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::directed::rx"))) (kind featureTyping) (ordinal 0) (authored-target "Message")
+      (outcome (status resolved) (target (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Message")))))
+    )
+  )
+  (query (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (range (start 13 26) (end 13 33)) (probe (position 13 26))
+    (reference (id (source (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::directed::tx"))) (kind featureTyping) (ordinal 0) (authored-target "Message")
+      (outcome (status resolved) (target (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Message")))))
+    )
+  )
+  (query (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (range (start 6 20) (end 6 26)) (probe (position 6 20))
     (reference (id (source (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Holder::good"))) (kind featureTyping) (ordinal 0) (authored-target "Signal")
       (outcome (status resolved) (target (node (document "memory://snapshot/sysml_port_usage_nested_usages_not_composite.md") (qualified-name "Ports::Signal")))))
     )


### PR DESCRIPTION
## What

`port_owned_usage_composite` (SysML 8.3.12.5) and `port_nested_usage_composite` (8.3.12.6) fired on directed `in item` / `out item` members of a `port def` / `port`. Those directed items are flow-feature declarations — the idiomatic SysML v2 spelling for a port's flow features — not the composite subparts the rule targets.

## Fix

A feature direction (`in` / `out` / `inout`) makes a usage referential, the same way the Pilot's `isReferenceDefault` treats every directed feature as a reference (which is already why a `ParameterUsage` is never composite). `usage_is_composite` in `crates/sysml_resolution/src/check/structural.rs` now returns `false` for any directed usage, so `collect_port_member_composition` skips them. Undirected composite usages (`part owned : Component;`) inside a port still report.

## Tests

- `tests/snapshots/validation/sysml_port_definition_owned_usages_not_composite.md` and `sysml_port_usage_nested_usages_not_composite.md` each gain a conforming directed-member `port def` / `port` (both sides of the rule).
- Eight corpus snapshots lose the false-positive diagnostic (all on `in`/`out item` flow features): `item_test`, `sys_ml_v2_spec_annex_a_simple_vehicle_model`, `vehicle_analysis_demo`, `10_port_example`, `10_port_conjugation_example`, `12_binding_connectors_example_1/2`, `3d_function_based_behavior_item`.

`cargo snapshot check` and `cargo test -p sysml_resolution` pass locally.

Fixes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)