### PR TITLE
Bump sysml-v2-parser to pick up the item-usage trailing-:> fix (#128)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **An item usage's `:>` subsetting clause trailing its own brace body attaches to that usage,
+  not a new member.** `item concern1 : Concern { doc /* ... */ } :> concerns;` (Apollo 11
+  `Purpose/StakeholderPackage.sysml`, 40 occurrences) previously split into two declarations --
+  `concern1` and a synthetic anonymous `attribute` member for the trailing `:> concerns` -- so
+  `spec42 check` reported a spurious `incompatible_subset_redefine_kind` warning (an
+  `Attribute`-family feature "subsetting" an `Item`-family one). Fixed upstream in the parser
+  (`elan8/sysml-v2-parser#137`), generalizing the existing `:>>`-trailing-a-body support
+  (`exhibit_state`) to `:>` and to item usage. Bumped the pinned parser revision. Fixes #128.
+
 - **A qualified reference to a standard-library symbol resolves inside a value expression, not
   only a typing clause or an import.** `attribute conversionFactor = RationalFunctions::rat(1,
   100);` (Apollo 11 `CoSMA/CoSMAQuantitiesAndUnitsPackage.sysml`) named `RationalFunctions` in

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2135,7 +2135,7 @@ dependencies = [
 [[package]]
 name = "sysml-v2-parser"
 version = "0.55.0"
-source = "git+https://github.com/elan8/sysml-v2-parser.git?rev=a5557ea0c28d5aac55206b8fa55861c2db098f71#a5557ea0c28d5aac55206b8fa55861c2db098f71"
+source = "git+https://github.com/elan8/sysml-v2-parser.git?rev=378e41b133ac6401547d737b11d0573548644f93#378e41b133ac6401547d737b11d0573548644f93"
 dependencies = [
  "log",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ clap = { version = "4", features = ["derive"] }
 petgraph = { version = "0.8", features = ["serde-1"] }
 sha2 = "0.10"
 blake3 = "1"
-sysml-v2-parser = { git = "https://github.com/elan8/sysml-v2-parser.git", rev = "a5557ea0c28d5aac55206b8fa55861c2db098f71", features = ["serde"] }
+sysml-v2-parser = { git = "https://github.com/elan8/sysml-v2-parser.git", rev = "378e41b133ac6401547d737b11d0573548644f93", features = ["serde"] }
 ts-rs = { version = "11", features = ["serde-compat", "serde-json-impl"] }
 zstd = "0.13"
 

--- a/tests/snapshots/resolution/item_usage_subsetting_after_brace_body.md
+++ b/tests/snapshots/resolution/item_usage_subsetting_after_brace_body.md
@@ -1,0 +1,221 @@
+# META
+~~~ini
+description=spec42#128 (Apollo 11 Purpose/StakeholderPackage.sysml, 40 occurrences): an item usage with a brace body subsets another item usage via a `:>` clause trailing the body. Both are item-family features, so the specialization is well-formed; a false `incompatible_subset_redefine_kind` regressed here when the trailing `:>` parsed as a new, keyword-less (attribute-family) member instead of concern1's own clause -- fixed in the parser (elan8/sysml-v2-parser#136/#137), not here. Negative control: subsetting an actually incompatible family still reports the kind mismatch.
+type=file
+~~~
+# SOURCE
+~~~sysml
+package ApolloItemSubsettingRepro {
+    item def Concern;
+    action def Objective;
+
+    part def Stakeholder {
+        item concerns[*] : Concern;
+        action objectives[*] : Objective;
+    }
+
+    part NASA : Stakeholder {
+        // Accepted: concern1 and concerns are both item-family, comparable in the occurrence
+        // hierarchy -- the trailing `:>` after concern1's own brace body is its own subsetting
+        // clause, not a separate member.
+        item concern1 : Concern {
+            doc /* Mission success. */
+        } :> concerns;
+
+        // Negative control: an item usage subsetting an actually incompatible family (action) is
+        // still reported.
+        item rejected : Concern {
+            doc /* Not an objective. */
+        } :> objectives;
+    }
+}
+~~~
+# EXPECTED DIAGNOSTICS
+~~~sexpr
+(fixture-diagnostics
+  (document "memory://snapshot/item_usage_subsetting_after_brace_body.md"
+    (diagnostics
+      (diagnostic
+        (severity warning)
+        (code "incompatible_subset_redefine_kind")
+        (source "semantic")
+        (range (start 21 13) (end 21 23))
+        (related-information
+          (related
+            (uri "memory://snapshot/item_usage_subsetting_after_brace_body.md")
+            (range (start 6 8) (end 6 41))
+          )
+        )
+      )
+    )
+  )
+)
+~~~
+# DIAGNOSTICS
+~~~sexpr
+(fixture-diagnostics
+  (document "memory://snapshot/item_usage_subsetting_after_brace_body.md"
+    (diagnostics
+      (diagnostic
+        (severity warning)
+        (code "incompatible_subset_redefine_kind")
+        (source "semantic")
+        (range (start 21 13) (end 21 23))
+        (related-information
+          (related
+            (uri "memory://snapshot/item_usage_subsetting_after_brace_body.md")
+            (range (start 6 8) (end 6 41))
+          )
+        )
+      )
+    )
+  )
+)
+~~~
+# SMG
+~~~sexpr
+(semantic-model
+  (publication (phase resolved) (completeness complete) (has-evaluation false) (source-digest "blake3:9011da7ac6dc66ab073c279c04e16f79078c0c10f00eb98628e952158e93fbae"))
+  (declarations
+    (declaration (id (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro"))) (kind package) (membership (kind owning) (visibility default)))
+    (declaration (id (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Concern"))) (kind item-def) (membership (kind owning) (visibility default)))
+    (declaration (id (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::NASA"))) (kind part) (membership (kind feature) (visibility default)) (authored (membership (kind feature) (visibility default)) (relationships (featureTyping (reference "Stakeholder")))))
+    (declaration (id (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::NASA::concern1"))) (kind item) (membership (kind feature) (visibility default)) (documentation (doc (text " Mission success. "))) (authored (membership (kind feature) (visibility default)) (relationships (featureTyping (reference "Concern")) (subsetting (reference "concerns")))))
+    (declaration (id (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::NASA::rejected"))) (kind item) (membership (kind feature) (visibility default)) (documentation (doc (text " Not an objective. "))) (authored (membership (kind feature) (visibility default)) (relationships (featureTyping (reference "Concern")) (subsetting (reference "objectives")))))
+    (declaration (id (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Objective"))) (kind action-def) (membership (kind owning) (visibility default)))
+    (declaration (id (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Stakeholder"))) (kind part-def) (membership (kind owning) (visibility default)))
+    (declaration (id (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Stakeholder::concerns"))) (kind item) (membership (kind feature) (visibility default)) (facts (multiplicity (lower unbounded) (upper unbounded))) (authored (membership (kind feature) (visibility default)) (relationships (featureTyping (reference "Concern")))))
+    (declaration (id (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Stakeholder::objectives"))) (kind action) (membership (kind feature) (visibility default)) (facts (modifiers composite) (multiplicity (lower unbounded) (upper unbounded))) (authored (membership (kind feature) (visibility default)) (relationships (featureTyping (reference "Objective")))))
+  )
+  (references
+    (reference (id (source (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::NASA"))) (kind featureTyping) (ordinal 0))
+      (authored-target "Stakeholder")
+      (outcome (status resolved) (target (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Stakeholder")))))
+    (reference (id (source (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::NASA::concern1"))) (kind featureTyping) (ordinal 0))
+      (authored-target "Concern")
+      (outcome (status resolved) (target (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Concern")))))
+    (reference (id (source (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::NASA::concern1"))) (kind subsetting) (ordinal 0))
+      (authored-target "concerns")
+      (outcome (status resolved) (target (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Stakeholder::concerns")))))
+    (reference (id (source (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::NASA::rejected"))) (kind featureTyping) (ordinal 0))
+      (authored-target "Concern")
+      (outcome (status resolved) (target (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Concern")))))
+    (reference (id (source (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::NASA::rejected"))) (kind subsetting) (ordinal 0))
+      (authored-target "objectives")
+      (outcome (status resolved) (target (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Stakeholder::objectives")))))
+    (reference (id (source (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Stakeholder::concerns"))) (kind featureTyping) (ordinal 0))
+      (authored-target "Concern")
+      (outcome (status resolved) (target (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Concern")))))
+    (reference (id (source (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Stakeholder::objectives"))) (kind featureTyping) (ordinal 0))
+      (authored-target "Objective")
+      (outcome (status resolved) (target (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Objective")))))
+  )
+  (relationships
+    (relationship (kind typing) (source (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::NASA"))) (target (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Stakeholder"))) (provenance authored) (authored-reference (source (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::NASA"))) (kind featureTyping) (ordinal 0)))
+    (relationship (kind typing) (source (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::NASA::concern1"))) (target (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Concern"))) (provenance authored) (authored-reference (source (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::NASA::concern1"))) (kind featureTyping) (ordinal 0)))
+    (relationship (kind subsetting) (source (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::NASA::concern1"))) (target (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Stakeholder::concerns"))) (provenance authored) (authored-reference (source (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::NASA::concern1"))) (kind subsetting) (ordinal 0)))
+    (relationship (kind typing) (source (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::NASA::rejected"))) (target (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Concern"))) (provenance authored) (authored-reference (source (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::NASA::rejected"))) (kind featureTyping) (ordinal 0)))
+    (relationship (kind subsetting) (source (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::NASA::rejected"))) (target (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Stakeholder::objectives"))) (provenance authored) (authored-reference (source (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::NASA::rejected"))) (kind subsetting) (ordinal 0)))
+    (relationship (kind typing) (source (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Stakeholder::concerns"))) (target (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Concern"))) (provenance authored) (authored-reference (source (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Stakeholder::concerns"))) (kind featureTyping) (ordinal 0)))
+    (relationship (kind typing) (source (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Stakeholder::objectives"))) (target (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Objective"))) (provenance authored) (authored-reference (source (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Stakeholder::objectives"))) (kind featureTyping) (ordinal 0)))
+    (relationship (kind typeFeaturing) (source (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::NASA::concern1"))) (target (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::NASA"))) (provenance implied))
+    (relationship (kind typeFeaturing) (source (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::NASA::rejected"))) (target (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::NASA"))) (provenance implied))
+    (relationship (kind typeFeaturing) (source (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Stakeholder::concerns"))) (target (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Stakeholder"))) (provenance implied))
+    (relationship (kind typeFeaturing) (source (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Stakeholder::objectives"))) (target (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Stakeholder"))) (provenance implied))
+  )
+  (evaluation
+  )
+)
+~~~
+# TYPES
+~~~sexpr
+(types
+    (declaration (id (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Concern")))
+      (subtype (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::NASA::concern1")) (scopes any))
+      (subtype (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::NASA::rejected")) (scopes any))
+      (subtype (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Stakeholder::concerns")) (scopes any))
+    )
+    (declaration (id (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::NASA")))
+      (type (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Stakeholder")) (provenance authored))
+      (effective-type (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Stakeholder")) (source direct))
+      (supertype (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Stakeholder")) (scopes any))
+    )
+    (declaration (id (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::NASA::concern1")))
+      (featured-by (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::NASA")))
+      (type (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Concern")) (provenance authored))
+      (effective-type (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Concern")) (source direct))
+      (effective-type (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Concern")) (source inherited) (from (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Stakeholder::concerns"))))
+      (supertype (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Concern")) (scopes any))
+      (supertype (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Stakeholder::concerns")) (scopes any feature))
+    )
+    (declaration (id (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::NASA::rejected")))
+      (featured-by (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::NASA")))
+      (type (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Concern")) (provenance authored))
+      (effective-type (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Concern")) (source direct))
+      (effective-type (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Objective")) (source inherited) (from (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Stakeholder::objectives"))))
+      (supertype (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Concern")) (scopes any))
+      (supertype (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Objective")) (scopes any))
+      (supertype (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Stakeholder::objectives")) (scopes any feature))
+    )
+    (declaration (id (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Objective")))
+      (subtype (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Stakeholder::objectives")) (scopes any))
+    )
+    (declaration (id (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Stakeholder")))
+      (subtype (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::NASA")) (scopes any))
+    )
+    (declaration (id (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Stakeholder::concerns")))
+      (featured-by (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Stakeholder")))
+      (type (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Concern")) (provenance authored))
+      (effective-type (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Concern")) (source direct))
+      (supertype (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Concern")) (scopes any))
+      (subtype (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::NASA::concern1")) (scopes any feature))
+    )
+    (declaration (id (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Stakeholder::objectives")))
+      (featured-by (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Stakeholder")))
+      (type (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Objective")) (provenance authored))
+      (effective-type (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Objective")) (source direct))
+      (supertype (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Objective")) (scopes any))
+      (subtype (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::NASA::rejected")) (scopes any feature))
+    )
+)
+~~~
+# NAVIGATION
+~~~sexpr
+(navigation
+  (query (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (range (start 9 16) (end 9 27)) (probe (position 9 16))
+    (reference (id (source (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::NASA"))) (kind featureTyping) (ordinal 0) (authored-target "Stakeholder")
+      (outcome (status resolved) (target (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Stakeholder")))))
+    )
+  )
+  (query (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (range (start 13 24) (end 13 31)) (probe (position 13 24))
+    (reference (id (source (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::NASA::concern1"))) (kind featureTyping) (ordinal 0) (authored-target "Concern")
+      (outcome (status resolved) (target (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Concern")))))
+    )
+  )
+  (query (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (range (start 15 13) (end 15 21)) (probe (position 15 13))
+    (reference (id (source (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::NASA::concern1"))) (kind subsetting) (ordinal 0) (authored-target "concerns")
+      (outcome (status resolved) (target (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Stakeholder::concerns")))))
+    )
+  )
+  (query (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (range (start 19 24) (end 19 31)) (probe (position 19 24))
+    (reference (id (source (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::NASA::rejected"))) (kind featureTyping) (ordinal 0) (authored-target "Concern")
+      (outcome (status resolved) (target (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Concern")))))
+    )
+  )
+  (query (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (range (start 21 13) (end 21 23)) (probe (position 21 13))
+    (reference (id (source (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::NASA::rejected"))) (kind subsetting) (ordinal 0) (authored-target "objectives")
+      (outcome (status resolved) (target (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Stakeholder::objectives")))))
+    )
+  )
+  (query (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (range (start 5 27) (end 5 34)) (probe (position 5 27))
+    (reference (id (source (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Stakeholder::concerns"))) (kind featureTyping) (ordinal 0) (authored-target "Concern")
+      (outcome (status resolved) (target (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Concern")))))
+    )
+  )
+  (query (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (range (start 6 31) (end 6 40)) (probe (position 6 31))
+    (reference (id (source (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Stakeholder::objectives"))) (kind featureTyping) (ordinal 0) (authored-target "Objective")
+      (outcome (status resolved) (target (node (document "memory://snapshot/item_usage_subsetting_after_brace_body.md") (qualified-name "ApolloItemSubsettingRepro::Objective")))))
+    )
+  )
+)
+~~~


### PR DESCRIPTION
## What

`item concern1 : Concern { doc /* Mission success. */ } :> concerns;` (Apollo 11 `Purpose/StakeholderPackage.sysml`, 40 occurrences) made `spec42 check` report a false `incompatible_subset_redefine_kind` on `concerns`.

## Root cause

Not a `sysml_resolution` validation bug -- the parser was splitting this into **two** declarations: `concern1` itself (typed by `Concern`, no subsetting), and a synthetic anonymous `attribute` member for the trailing `:> concerns` (the parser's keyword-less-member fallback, since nothing told it the `:>` belonged to `concern1`). `check_reference_kind` was correctly flagging the (wrongly-shaped) input it was handed: an `Attribute`-family feature "subsetting" an `Item`-family one.

Root-caused and fixed upstream in `elan8/sysml-v2-parser#137` (issue elan8/sysml-v2-parser#136): a `:>` trailing a brace body now attaches to that same usage, generalizing the existing `:>>`-trailing-a-body precedent (`exhibit_state`, `part/body.rs`) to `:>` and to `item` usage, gated to brace bodies only (a semicolon body already ends the statement).

## Change here

- Bump the pinned `sysml-v2-parser` rev to the merged fix (`378e41b`) and `Cargo.lock` to match.
- New fixture `tests/snapshots/resolution/item_usage_subsetting_after_brace_body.md`: the exact Apollo shape (accepted, no diagnostic) plus a negative control -- an item usage subsetting an actually incompatible family (`action`) still reports the kind mismatch.

## Tests

- Manual CLI verification: the original repro now produces 0 diagnostics.
- New fixture, both the positive case (no diagnostic) and the negative control (correctly still flagged).
- Full corpus `cargo run -p spec42-snapshot -- check`: 922 fixtures, 0 failed (161 passed, up 1; nothing else shifted from the parser bump).
- `cargo test --workspace --exclude server --exclude lsp_server`, `cargo test -p lsp_server --lib --test debt_guardrails --test parse_validation`, full `cargo test -p lsp_server --test lsp_integration -- --test-threads=1` (102/102), `cargo test -p server --lib` all green.
- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -D warnings`, `RUSTDOCFLAGS=-D warnings cargo doc --workspace` all clean.

Fixes #128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)